### PR TITLE
chore: build package as part of npm prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "npm run lint",
+    "prepare": "tsc",
     "build": "tsc",
     "lint": "eslint src/** --fix",
     "coverage": "npm test -- --coverage --no-cache",


### PR DESCRIPTION
This allows the package to be referenced as a github package & building to occur as part of the `npm install` process.