### PR TITLE
feat: support matchesPattern string function

### DIFF
--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -343,6 +343,7 @@ export function boolMethodCallExpr(
     endsWithMethodCallExpr(value, index) ||
     startsWithMethodCallExpr(value, index) ||
     containsMethodCallExpr(value, index) ||
+    matchesPatternMethodCallExpr(value, index) ||
     intersectsMethodCallExpr(value, index)
   );
 }
@@ -463,6 +464,12 @@ export function endsWithMethodCallExpr(
   index: number
 ): Lexer.Token {
   return methodCallExprFactory(value, index, 'endswith', 2);
+}
+export function matchesPatternMethodCallExpr(
+  value: SourceArray,
+  index: number
+): Lexer.Token {
+  return methodCallExprFactory(value, index, 'matchespattern', 2);
 }
 export function lengthMethodCallExpr(
   value: SourceArray,

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -19,6 +19,16 @@ describe('Parser', () => {
     expect(ast.value.options[0].type).toEqual('Filter');
   });
 
+  it('should parse functions with parameters', () => {
+    const parser = new Parser();
+    const ast = parser.filter("matchespattern(Title, '^foo.+')");
+    expect(ast.type).toEqual('MethodCallExpression');
+    expect(ast.value.method).toEqual('matchespattern');
+    expect(ast.value.parameters[0].raw).toEqual('Title');
+    expect(ast.value.parameters[1].raw).toEqual("'^foo.+'");
+    expect(ast.value.parameters[1].value).toEqual('Edm.String');
+  });
+
   it('should parse multiple orderby params', () => {
     const parser = new Parser();
     const ast = parser.query('$orderby=foo,bar');
@@ -49,11 +59,9 @@ describe('Parser', () => {
       expect(ast.value.options[1].value.key).toEqual('bar');
       expect(ast.value.options[1].value.value).toEqual('foobar');
     }
-
   });
 
   it('should throw error parsing invalid custom query options', () => {
     expect(() => {defaultParser.query('$foo=123');}).toThrow();
   });
-
 });


### PR DESCRIPTION
## Describe your changes

Adds support for the [matchesPattern](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_matchesPattern) function.

## Issue ticket number and link (if applicable)

Related to [#36](https://github.com/Soontao/odata-v4-parser/issues/36).

## Checklist before requesting a review

- [x] Project license confirmed
- [x] Unit-test added & passed at local development environment
- [x] All CI check passed
- [ ] Design Document (if applicable)