### PR TITLE
enforce strict token type/value combinations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.organizeImports": true
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
   },
   "jest.autoEnable": false,
   "cSpell.words": [
@@ -11,5 +11,7 @@
     "datetimeoffset",
     "inlinecount",
     "odata"
-  ]
+  ],
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -2,10 +2,32 @@ import * as ArrayOrObject from './json';
 import * as Lexer from './lexer';
 import * as NameOrIdentifier from './nameOrIdentifier';
 import * as PrimitiveLiteral from './primitiveLiteral';
+import * as Token from './token';
 import Utils, { SourceArray } from './utils';
 
-export function commonExpr(value: SourceArray, index: number): Lexer.Token {
-  const token =
+export function commonExpr(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.CommonExpression> {
+  let token:
+    | Lexer.Token<Lexer.TokenType.Literal>
+    | Lexer.Token<Lexer.TokenType.Enum>
+    | Lexer.Token<Lexer.TokenType.ParameterAlias>
+    | Lexer.Token<Lexer.TokenType.ArrayOrObject>
+    | Lexer.Token<Lexer.TokenType.RootExpression>
+    | Lexer.Token<Lexer.TokenType.MethodCallExpression>
+    | Lexer.Token<Lexer.TokenType.FirstMemberExpression>
+    | Lexer.Token<Lexer.TokenType.FunctionExpression>
+    | Lexer.Token<Lexer.TokenType.NegateExpression>
+    | Lexer.Token<Lexer.TokenType.ParenExpression>
+    | Lexer.Token<Lexer.TokenType.CastExpression>
+    | Lexer.Token<Lexer.TokenType.AddExpression>
+    | Lexer.Token<Lexer.TokenType.SubExpression>
+    | Lexer.Token<Lexer.TokenType.MulExpression>
+    | Lexer.Token<Lexer.TokenType.DivExpression>
+    | Lexer.Token<Lexer.TokenType.ModExpression>
+    | Lexer.Token<Lexer.TokenType.AndExpression>
+    | Lexer.Token<Lexer.TokenType.OrExpression> =
     PrimitiveLiteral.primitiveLiteral(value, index) ||
     parameterAlias(value, index) ||
     ArrayOrObject.arrayOrObject(value, index) ||
@@ -29,13 +51,16 @@ export function commonExpr(value: SourceArray, index: number): Lexer.Token {
     modExpr(value, token.next);
 
   if (expr) {
-    token.value = {
-      left: Lexer.clone(token),
-      right: expr.value
-    };
-    token.next = expr.value.next;
-    token.type = expr.type;
-    token.raw = Utils.stringify(value, token.position, token.next);
+    token = new Lexer.Token({
+      ...token,
+      type: expr.type,
+      value: {
+        left: Lexer.clone(token),
+        right: expr.value
+      },
+      next: expr.value.next,
+      raw: Utils.stringify(value, token.position, token.next)
+    });
   }
 
   if (token) {
@@ -49,8 +74,37 @@ export function commonExpr(value: SourceArray, index: number): Lexer.Token {
   }
 }
 
-export function boolCommonExpr(value: SourceArray, index: number): Lexer.Token {
-  const token =
+export function boolCommonExpr(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.IsOfExpression>
+   | Lexer.Token<Lexer.TokenType.MethodCallExpression>
+   | Lexer.Token<Lexer.TokenType.NotExpression>
+   | Lexer.Token<Lexer.TokenType.CommonExpression>
+   | Lexer.Token<Lexer.TokenType.BoolParenExpression>
+   | Lexer.Token<Lexer.TokenType.EqualsExpression>
+   | Lexer.Token<Lexer.TokenType.NotEqualsExpression>
+   | Lexer.Token<Lexer.TokenType.LesserThanExpression>
+   | Lexer.Token<Lexer.TokenType.LesserOrEqualsExpression>
+   | Lexer.Token<Lexer.TokenType.GreaterThanExpression>
+   | Lexer.Token<Lexer.TokenType.GreaterOrEqualsExpression>
+   | Lexer.Token<Lexer.TokenType.HasExpression>
+   | Lexer.Token<Lexer.TokenType.AndExpression>
+   | Lexer.Token<Lexer.TokenType.OrExpression> {
+  let token: Lexer.Token<Lexer.TokenType.IsOfExpression>
+    | Lexer.Token<Lexer.TokenType.MethodCallExpression>
+    | Lexer.Token<Lexer.TokenType.NotExpression>
+    | Lexer.Token<Lexer.TokenType.CommonExpression>
+    | Lexer.Token<Lexer.TokenType.BoolParenExpression>
+    | Lexer.Token<Lexer.TokenType.EqualsExpression>
+    | Lexer.Token<Lexer.TokenType.NotEqualsExpression>
+    | Lexer.Token<Lexer.TokenType.LesserThanExpression>
+    | Lexer.Token<Lexer.TokenType.LesserOrEqualsExpression>
+    | Lexer.Token<Lexer.TokenType.GreaterThanExpression>
+    | Lexer.Token<Lexer.TokenType.GreaterOrEqualsExpression>
+    | Lexer.Token<Lexer.TokenType.HasExpression>
+    | Lexer.Token<Lexer.TokenType.AndExpression>
+    | Lexer.Token<Lexer.TokenType.OrExpression> =
     isofExpr(value, index) ||
     boolMethodCallExpr(value, index) ||
     notExpr(value, index) ||
@@ -61,9 +115,8 @@ export function boolCommonExpr(value: SourceArray, index: number): Lexer.Token {
     return;
   }
 
-  let commonMoreExpr = undefined;
-  if (token. type === Lexer.TokenType.CommonExpression) {
-    commonMoreExpr =
+  if (token.type === Lexer.TokenType.CommonExpression) {
+    const commonMoreExpr =
       eqExpr(value, token.next) ||
       neExpr(value, token.next) ||
       ltExpr(value, token.next) ||
@@ -73,13 +126,13 @@ export function boolCommonExpr(value: SourceArray, index: number): Lexer.Token {
       hasExpr(value, token.next);
 
     if (commonMoreExpr) {
-      token.value = {
-        left: token.value,
-        right: commonMoreExpr.value
-      };
-      token.next = commonMoreExpr.value.next;
-      token.type = commonMoreExpr.type;
-      token.raw = Utils.stringify(value, token.position, token.next);
+      token = new Lexer.Token({
+        ...token,
+        type: commonMoreExpr.type,
+        value: { left: token.value, right: commonMoreExpr.value },
+        next: commonMoreExpr.value.next,
+        raw: Utils.stringify(value, token.position, commonMoreExpr.value.next)
+      });
     }
   }
 
@@ -87,19 +140,19 @@ export function boolCommonExpr(value: SourceArray, index: number): Lexer.Token {
 
   if (expr) {
     const left = Lexer.clone(token);
-    token.next = expr.value.next;
-    token.value = {
-      left,
-      right: expr.value
-    };
-    token.type = expr.type;
-    token.raw = Utils.stringify(value, token.position, token.next);
+    token = new Lexer.Token({
+      ...token,
+      type: expr.type,
+      value: { left, right: expr.value },
+      next: expr.value.next,
+      raw: Utils.stringify(value, token.position, expr.value.next)
+    });
 
     if (
       token.type === Lexer.TokenType.AndExpression &&
       token.value.right.type === Lexer.TokenType.OrExpression
     ) {
-      token.value.left = Lexer.tokenize(
+      const left = Lexer.tokenize(
         value,
         token.value.left.position,
         token.value.right.value.left.next,
@@ -109,15 +162,49 @@ export function boolCommonExpr(value: SourceArray, index: number): Lexer.Token {
         },
         token.type
       );
-      token.type = token.value.right.type;
-      token.value.right = token.value.right.value.right;
+      const right = token.value.right.value.right;
+      token = new Lexer.Token({
+        ...token,
+        type: token.value.right.type,
+        value: { left, right }
+      });
     }
   }
 
   return token;
 }
 
-export function andExpr(value: SourceArray, index: number): Lexer.Token {
+interface InternalAndOrExpression<T extends Lexer.TokenType.AndExpression | Lexer.TokenType.OrExpression> {
+  type: T;
+  value: Token.TokenTypeValue<T>['right'];
+  position: number;
+  next: number;
+  raw: string;
+}
+
+interface InternalLeftRightExpression<T extends InternalLeftRightTokenType> {
+  type: T;
+  value: Token.TokenTypeValue<T>['right'];
+  position: number;
+  next: number;
+  raw: string;
+}
+
+type InternalLeftRightTokenType =
+  | Lexer.TokenType.EqualsExpression
+  | Lexer.TokenType.NotEqualsExpression
+  | Lexer.TokenType.LesserThanExpression
+  | Lexer.TokenType.LesserOrEqualsExpression
+  | Lexer.TokenType.GreaterThanExpression
+  | Lexer.TokenType.GreaterOrEqualsExpression
+  | Lexer.TokenType.HasExpression
+  | Lexer.TokenType.AddExpression
+  | Lexer.TokenType.SubExpression
+  | Lexer.TokenType.MulExpression
+  | Lexer.TokenType.DivExpression
+  | Lexer.TokenType.ModExpression;
+
+export function andExpr(value: SourceArray, index: number): InternalAndOrExpression<Lexer.TokenType.AndExpression> {
   let rws = Lexer.RWS(value, index);
   if (rws === index || !Utils.equals(value, rws, 'and')) {
     return;
@@ -134,16 +221,16 @@ export function andExpr(value: SourceArray, index: number): Lexer.Token {
     return;
   }
 
-  return Lexer.tokenize(
-    value,
-    start,
-    index,
-    token,
-    Lexer.TokenType.AndExpression
-  );
+  return {
+    type: Lexer.TokenType.AndExpression,
+    value: token,
+    position: start,
+    next: index,
+    raw: Utils.stringify(value, start, index)
+  };
 }
 
-export function orExpr(value: SourceArray, index: number): Lexer.Token {
+export function orExpr(value: SourceArray, index: number): InternalAndOrExpression<Lexer.TokenType.OrExpression> {
   let rws = Lexer.RWS(value, index);
   if (rws === index || !Utils.equals(value, rws, 'or')) {
     return;
@@ -160,21 +247,21 @@ export function orExpr(value: SourceArray, index: number): Lexer.Token {
     return;
   }
 
-  return Lexer.tokenize(
-    value,
-    start,
-    index,
-    token,
-    Lexer.TokenType.OrExpression
-  );
+  return {
+    type: Lexer.TokenType.OrExpression,
+    value: token,
+    position: start,
+    next: index,
+    raw: Utils.stringify(value, start, index)
+  };
 }
 
-export function leftRightExpr(
+export function leftRightExpr<T extends InternalLeftRightTokenType>(
   value: SourceArray,
   index: number,
   expr: string,
-  tokenType: Lexer.TokenType
-): Lexer.Token {
+  tokenType: T
+): InternalLeftRightExpression<T> {
   let rws = Lexer.RWS(value, index);
   if (rws === index) {
     return;
@@ -195,15 +282,21 @@ export function leftRightExpr(
     return;
   }
 
-  return Lexer.tokenize(value, start, index, token.value, tokenType);
+  return {
+    type: tokenType,
+    value: token.value,
+    position: start,
+    next: index,
+    raw: Utils.stringify(value, start, index)
+  };
 }
-export function eqExpr(value: SourceArray, index: number): Lexer.Token {
+export function eqExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.EqualsExpression> {
   return leftRightExpr(value, index, 'eq', Lexer.TokenType.EqualsExpression);
 }
-export function neExpr(value: SourceArray, index: number): Lexer.Token {
+export function neExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.NotEqualsExpression> {
   return leftRightExpr(value, index, 'ne', Lexer.TokenType.NotEqualsExpression);
 }
-export function ltExpr(value: SourceArray, index: number): Lexer.Token {
+export function ltExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.LesserThanExpression> {
   return leftRightExpr(
     value,
     index,
@@ -211,7 +304,7 @@ export function ltExpr(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.LesserThanExpression
   );
 }
-export function leExpr(value: SourceArray, index: number): Lexer.Token {
+export function leExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.LesserOrEqualsExpression> {
   return leftRightExpr(
     value,
     index,
@@ -219,7 +312,7 @@ export function leExpr(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.LesserOrEqualsExpression
   );
 }
-export function gtExpr(value: SourceArray, index: number): Lexer.Token {
+export function gtExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.GreaterThanExpression> {
   return leftRightExpr(
     value,
     index,
@@ -227,7 +320,7 @@ export function gtExpr(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.GreaterThanExpression
   );
 }
-export function geExpr(value: SourceArray, index: number): Lexer.Token {
+export function geExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.GreaterOrEqualsExpression> {
   return leftRightExpr(
     value,
     index,
@@ -235,27 +328,27 @@ export function geExpr(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.GreaterOrEqualsExpression
   );
 }
-export function hasExpr(value: SourceArray, index: number): Lexer.Token {
+export function hasExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.HasExpression> {
   return leftRightExpr(value, index, 'has', Lexer.TokenType.HasExpression);
 }
 
-export function addExpr(value: SourceArray, index: number): Lexer.Token {
+export function addExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.AddExpression> {
   return leftRightExpr(value, index, 'add', Lexer.TokenType.AddExpression);
 }
-export function subExpr(value: SourceArray, index: number): Lexer.Token {
+export function subExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.SubExpression> {
   return leftRightExpr(value, index, 'sub', Lexer.TokenType.SubExpression);
 }
-export function mulExpr(value: SourceArray, index: number): Lexer.Token {
+export function mulExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.MulExpression> {
   return leftRightExpr(value, index, 'mul', Lexer.TokenType.MulExpression);
 }
-export function divExpr(value: SourceArray, index: number): Lexer.Token {
+export function divExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.DivExpression> {
   return leftRightExpr(value, index, 'div', Lexer.TokenType.DivExpression);
 }
-export function modExpr(value: SourceArray, index: number): Lexer.Token {
+export function modExpr(value: SourceArray, index: number): InternalLeftRightExpression<Lexer.TokenType.ModExpression> {
   return leftRightExpr(value, index, 'mod', Lexer.TokenType.ModExpression);
 }
 
-export function notExpr(value: SourceArray, index: number): Lexer.Token {
+export function notExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.NotExpression> {
   if (!Utils.equals(value, index, 'not')) {
     return;
   }
@@ -280,7 +373,7 @@ export function notExpr(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function boolParenExpr(value: SourceArray, index: number): Lexer.Token {
+export function boolParenExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.BoolParenExpression> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -307,7 +400,7 @@ export function boolParenExpr(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.BoolParenExpression
   );
 }
-export function parenExpr(value: SourceArray, index: number): Lexer.Token {
+export function parenExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.ParenExpression> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -338,7 +431,7 @@ export function parenExpr(value: SourceArray, index: number): Lexer.Token {
 export function boolMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return (
     endsWithMethodCallExpr(value, index) ||
     startsWithMethodCallExpr(value, index) ||
@@ -347,7 +440,10 @@ export function boolMethodCallExpr(
     intersectsMethodCallExpr(value, index)
   );
 }
-export function methodCallExpr(value: SourceArray, index: number): Lexer.Token {
+export function methodCallExpr(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return (
     indexOfMethodCallExpr(value, index) ||
     toLowerMethodCallExpr(value, index) ||
@@ -384,7 +480,7 @@ export function methodCallExprFactory(
   method: string,
   min?: number,
   max?: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   if (typeof min === 'undefined') {
     min = 0;
   }
@@ -450,201 +546,201 @@ export function methodCallExprFactory(
 export function containsMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'contains', 2);
 }
 export function startsWithMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'startswith', 2);
 }
 export function endsWithMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'endswith', 2);
 }
 export function matchesPatternMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'matchespattern', 2);
 }
 export function lengthMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'length', 1);
 }
 export function indexOfMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'indexof', 2);
 }
 export function substringMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'substring', 2, 3);
 }
 export function substringOfMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'substringof', 2);
 }
 export function toLowerMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'tolower', 1);
 }
 export function toUpperMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'toupper', 1);
 }
 export function trimMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'trim', 1);
 }
 export function concatMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'concat', 2);
 }
 
 export function yearMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'year', 1);
 }
 export function monthMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'month', 1);
 }
 export function dayMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'day', 1);
 }
 export function hourMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'hour', 1);
 }
 export function minuteMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'minute', 1);
 }
 export function secondMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'second', 1);
 }
 export function fractionalsecondsMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'fractionalseconds', 1);
 }
 export function totalsecondsMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'totalseconds', 1);
 }
 export function dateMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'date', 1);
 }
 export function timeMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'time', 1);
 }
 export function totalOffsetMinutesMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'totaloffsetminutes', 1);
 }
 
 export function minDateTimeMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'mindatetime', 0);
 }
 export function maxDateTimeMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'maxdatetime', 0);
 }
 export function nowMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'now', 0);
 }
 
 export function roundMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'round', 1);
 }
 export function floorMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'floor', 1);
 }
 export function ceilingMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'ceiling', 1);
 }
 
 export function distanceMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'geo.distance', 2);
 }
 export function geoLengthMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'geo.length', 1);
 }
 export function intersectsMethodCallExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.MethodCallExpression> {
   return methodCallExprFactory(value, index, 'geo.intersects', 2);
 }
 
-export function isofExpr(value: SourceArray, index: number): Lexer.Token {
+export function isofExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.IsOfExpression> {
   if (!Utils.equals(value, index, 'isof')) {
     return;
   }
@@ -690,7 +786,7 @@ export function isofExpr(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.IsOfExpression
   );
 }
-export function castExpr(value: SourceArray, index: number): Lexer.Token {
+export function castExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.CastExpression> {
   if (!Utils.equals(value, index, 'cast')) {
     return;
   }
@@ -737,7 +833,7 @@ export function castExpr(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function negateExpr(value: SourceArray, index: number): Lexer.Token {
+export function negateExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.NegateExpression> {
   if (value[index] !== 0x2d) {
     return;
   }
@@ -761,9 +857,9 @@ export function negateExpr(value: SourceArray, index: number): Lexer.Token {
 export function firstMemberExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
-  let token = inscopeVariableExpr(value, index);
-  let member;
+): Lexer.Token<Lexer.TokenType.FirstMemberExpression> {
+  const token = inscopeVariableExpr(value, index);
+  let member: Lexer.Token<Lexer.TokenType.MemberExpression>;
   const start = index;
 
   if (token) {
@@ -786,20 +882,20 @@ export function firstMemberExpr(
     member = memberExpr(value, index);
   }
 
-  token = token || member;
-  if (!token) {
+  const firstToken = token || member;
+  if (!firstToken) {
     return;
   }
 
   return Lexer.tokenize(
     value,
     start,
-    token.next,
-    token,
+    firstToken.next,
+    firstToken,
     Lexer.TokenType.FirstMemberExpression
   );
 }
-export function memberExpr(value: SourceArray, index: number): Lexer.Token {
+export function memberExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.MemberExpression> {
   const start = index;
   const token = NameOrIdentifier.qualifiedEntityTypeName(value, index);
 
@@ -827,8 +923,12 @@ export function memberExpr(value: SourceArray, index: number): Lexer.Token {
 export function propertyPathExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
-  let token: any = NameOrIdentifier.odataIdentifier(value, index);
+): Lexer.Token<Lexer.TokenType.PropertyPathExpression> {
+  let token: Token.PropertyPathExpressionToken['value'] = NameOrIdentifier.odataIdentifier(
+    value,
+    index,
+    Lexer.TokenType.ODataIdentifier
+  );
   const start = index;
   if (token) {
     index = token.next;
@@ -867,7 +967,7 @@ export function propertyPathExpr(
 export function inscopeVariableExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.ImplicitVariableExpression> | Lexer.Token<Lexer.TokenType.LambdaVariableExpression> | Lexer.Token<Lexer.TokenType.ODataIdentifier> {
   return (
     implicitVariableExpr(value, index) ||
     (isLambdaPredicate ? lambdaVariableExpr(value, index) : undefined)
@@ -876,7 +976,7 @@ export function inscopeVariableExpr(
 export function implicitVariableExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.ImplicitVariableExpression> {
   if (Utils.equals(value, index, '$it')) {
     return Lexer.tokenize(
       value,
@@ -892,7 +992,7 @@ let hasLambdaVariableExpr = false;
 export function lambdaVariableExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.LambdaVariableExpression> {
   const token = NameOrIdentifier.odataIdentifier(
     value,
     index,
@@ -906,7 +1006,7 @@ export function lambdaVariableExpr(
 export function lambdaPredicateExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.LambdaPredicateExpression> {
   isLambdaPredicate = true;
   const token = boolCommonExpr(value, index);
   isLambdaPredicate = false;
@@ -921,7 +1021,7 @@ export function lambdaPredicateExpr(
     );
   }
 }
-export function anyExpr(value: SourceArray, index: number): Lexer.Token {
+export function anyExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.AnyExpression> {
   if (!Utils.equals(value, index, 'any')) {
     return;
   }
@@ -968,7 +1068,7 @@ export function anyExpr(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.AnyExpression
   );
 }
-export function allExpr(value: SourceArray, index: number): Lexer.Token {
+export function allExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.AllExpression> {
   if (!Utils.equals(value, index, 'all')) {
     return;
   }
@@ -1027,7 +1127,7 @@ export function allExpr(value: SourceArray, index: number): Lexer.Token {
 export function collectionNavigationExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.CollectionNavigationExpression> {
   const start = index;
   let entity, navigation, path;
   if (value[index] === 0x2f) {
@@ -1072,15 +1172,15 @@ export function collectionNavigationExpr(
 export function keyPredicate(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.SimpleKey> | Lexer.Token<Lexer.TokenType.CompoundKey> {
   return simpleKey(value, index, metadataContext) || compoundKey(value, index);
 }
 export function simpleKey(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.SimpleKey> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -1098,16 +1198,7 @@ export function simpleKey(
     return;
   }
 
-  let key;
-  if (
-    typeof metadataContext === 'object' &&
-    metadataContext.key &&
-    metadataContext.key.propertyRefs &&
-    metadataContext.key.propertyRefs[0] &&
-    metadataContext.key.propertyRefs[0].name
-  ) {
-    key = metadataContext.key.propertyRefs[0].name;
-  }
+  const key = metadataContext?.key?.propertyRefs?.[0]?.name;
 
   return Lexer.tokenize(
     value,
@@ -1117,7 +1208,7 @@ export function simpleKey(
     Lexer.TokenType.SimpleKey
   );
 }
-export function compoundKey(value: SourceArray, index: number): Lexer.Token {
+export function compoundKey(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.CompoundKey> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -1150,7 +1241,7 @@ export function compoundKey(value: SourceArray, index: number): Lexer.Token {
 
   return Lexer.tokenize(value, start, index, keys, Lexer.TokenType.CompoundKey);
 }
-export function keyValuePair(value: SourceArray, index: number): Lexer.Token {
+export function keyValuePair(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.KeyValuePair> {
   const prop =
     NameOrIdentifier.primitiveKeyProperty(value, index) ||
     keyPropertyAlias(value, index);
@@ -1180,17 +1271,20 @@ export function keyValuePair(value: SourceArray, index: number): Lexer.Token {
 export function keyPropertyValue(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.KeyPropertyValue> {
   const token = PrimitiveLiteral.primitiveLiteral(value, index);
   if (token) {
-    token.type = Lexer.TokenType.KeyPropertyValue;
-    return token;
+    return new Lexer.Token({
+      ...token,
+      type: Lexer.TokenType.KeyPropertyValue,
+      value: String(token.value)
+    });
   }
 }
 export function keyPropertyAlias(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.KeyPropertyAlias> {
   return NameOrIdentifier.odataIdentifier(
     value,
     index,
@@ -1201,7 +1295,7 @@ export function keyPropertyAlias(
 export function singleNavigationExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.SingleNavigationExpression> {
   if (value[index] !== 0x2f) {
     return;
   }
@@ -1219,8 +1313,12 @@ export function singleNavigationExpr(
 export function collectionPathExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
-  let token = countExpr(value, index);
+): Lexer.Token<Lexer.TokenType.CollectionPathExpression> {
+  let token:
+    | Lexer.Token<Lexer.TokenType.CountExpression>
+    | Lexer.Token<Lexer.TokenType.FunctionExpression>
+    | Lexer.Token<Lexer.TokenType.AnyExpression>
+    | Lexer.Token<Lexer.TokenType.AllExpression> = countExpr(value, index);
   if (!token) {
     if (value[index] === 0x2f) {
       token =
@@ -1243,7 +1341,7 @@ export function collectionPathExpr(
 export function complexPathExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.ComplexPathExpression> {
   if (value[index] !== 0x2f) {
     return;
   }
@@ -1270,7 +1368,7 @@ export function complexPathExpr(
     );
   }
 }
-export function singlePathExpr(value: SourceArray, index: number): Lexer.Token {
+export function singlePathExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.SinglePathExpression> {
   if (value[index] !== 0x2f) {
     return;
   }
@@ -1285,7 +1383,7 @@ export function singlePathExpr(value: SourceArray, index: number): Lexer.Token {
     );
   }
 }
-export function functionExpr(value: SourceArray, index: number): Lexer.Token {
+export function functionExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.FunctionExpression> {
   const namespaceNext = NameOrIdentifier.namespace(value, index);
   if (namespaceNext === index || value[namespaceNext] !== 0x2e) {
     return;
@@ -1293,7 +1391,11 @@ export function functionExpr(value: SourceArray, index: number): Lexer.Token {
   const start = index;
   index = namespaceNext + 1;
 
-  const token = NameOrIdentifier.odataIdentifier(value, index);
+  const token = NameOrIdentifier.odataIdentifier(
+    value,
+    index,
+    Lexer.TokenType.ODataIdentifier
+  );
 
   if (!token) {
     return;
@@ -1325,25 +1427,21 @@ export function functionExpr(value: SourceArray, index: number): Lexer.Token {
     value,
     start,
     index,
-    {
-      fn: token,
-      params,
-      expression: expr
-    },
+    { fn: token, params, expression: expr },
     Lexer.TokenType.FunctionExpression
   );
 }
 export function boundFunctionExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.FunctionExpression> {
   return functionExpr(value, index);
 }
 
 export function functionExprParameters(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.FunctionExpressionParameters> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -1385,7 +1483,7 @@ export function functionExprParameters(
 export function functionExprParameter(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.FunctionExpressionParameter> {
   const name = parameterName(value, index);
   if (!name) {
     return;
@@ -1414,19 +1512,19 @@ export function functionExprParameter(
     Lexer.TokenType.FunctionExpressionParameter
   );
 }
-export function parameterName(value: SourceArray, index: number): Lexer.Token {
+export function parameterName(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.ParameterName> {
   return NameOrIdentifier.odataIdentifier(
     value,
     index,
     Lexer.TokenType.ParameterName
   );
 }
-export function parameterAlias(value: SourceArray, index: number): Lexer.Token {
+export function parameterAlias(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.ParameterAlias> {
   const at = Lexer.AT(value, index);
   if (!at) {
     return;
   }
-  const id = NameOrIdentifier.odataIdentifier(value, at);
+  const id = NameOrIdentifier.odataIdentifier(value, at, Lexer.TokenType.ODataIdentifier);
   if (id) {
     return Lexer.tokenize(
       value,
@@ -1437,7 +1535,7 @@ export function parameterAlias(value: SourceArray, index: number): Lexer.Token {
     );
   }
 }
-export function parameterValue(value: SourceArray, index: number): Lexer.Token {
+export function parameterValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.ParameterValue> {
   const token =
     ArrayOrObject.arrayOrObject(value, index) || commonExpr(value, index);
   if (token) {
@@ -1451,7 +1549,7 @@ export function parameterValue(value: SourceArray, index: number): Lexer.Token {
   }
 }
 
-export function countExpr(value: SourceArray, index: number): Lexer.Token {
+export function countExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.CountExpression> {
   if (Utils.equals(value, index, '/$count')) {
     return Lexer.tokenize(
       value,
@@ -1462,7 +1560,7 @@ export function countExpr(value: SourceArray, index: number): Lexer.Token {
     );
   }
 }
-export function refExpr(value: SourceArray, index: number): Lexer.Token {
+export function refExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.RefExpression> {
   if (Utils.equals(value, index, '/$ref')) {
     return Lexer.tokenize(
       value,
@@ -1473,7 +1571,7 @@ export function refExpr(value: SourceArray, index: number): Lexer.Token {
     );
   }
 }
-export function valueExpr(value: SourceArray, index: number): Lexer.Token {
+export function valueExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.ValueExpression> {
   if (Utils.equals(value, index, '/$value')) {
     return Lexer.tokenize(
       value,
@@ -1485,7 +1583,7 @@ export function valueExpr(value: SourceArray, index: number): Lexer.Token {
   }
 }
 
-export function rootExpr(value: SourceArray, index: number): Lexer.Token {
+export function rootExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.RootExpression> {
   if (!Utils.equals(value, index, '$root/')) {
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ export * from './builder';
 export * from './constants';
 export * from './lexer';
 export * from './token';
-export * from './types';
 export * from './visitor';
 
 export const defaultParser = new Parser();

--- a/src/json.ts
+++ b/src/json.ts
@@ -7,7 +7,7 @@ import Utils, { SourceArray } from './utils';
 export function complexColInUri(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Array> {
   const begin = Lexer.beginArray(value, index);
   if (begin === index) {
     return;
@@ -15,7 +15,7 @@ export function complexColInUri(
   const start = index;
   index = begin;
 
-  const items = [];
+  const items: Lexer.Token<Lexer.TokenType.Object>[] = [];
   let token = complexInUri(value, index);
   if (token) {
     while (token) {
@@ -50,7 +50,7 @@ export function complexColInUri(
   return Lexer.tokenize(value, start, index, { items }, Lexer.TokenType.Array);
 }
 
-export function complexInUri(value: SourceArray, index: number): Lexer.Token {
+export function complexInUri(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Object> {
   const begin = Lexer.beginObject(value, index);
   if (begin === index) {
     return;
@@ -106,7 +106,7 @@ export function complexInUri(value: SourceArray, index: number): Lexer.Token {
 export function collectionPropertyInUri(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Property> {
   let mark = Lexer.quotationMark(value, index);
   if (mark === index) {
     return;
@@ -157,7 +157,7 @@ export function collectionPropertyInUri(
 export function primitiveColInUri(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Array> {
   const begin = Lexer.beginArray(value, index);
   if (begin === index) {
     return;
@@ -203,7 +203,7 @@ export function primitiveColInUri(
 export function complexPropertyInUri(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Property> {
   let mark = Lexer.quotationMark(value, index);
   if (mark === index) {
     return;
@@ -247,7 +247,7 @@ export function complexPropertyInUri(
 export function annotationInUri(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Annotation> {
   let mark = Lexer.quotationMark(value, index);
   if (mark === index) {
     return;
@@ -320,7 +320,7 @@ export function keyValuePairInUri(
   index: number,
   keyFn: Function,
   valueFn: Function
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Property> {
   let mark = Lexer.quotationMark(value, index);
   if (mark === index) {
     return;
@@ -364,7 +364,7 @@ export function keyValuePairInUri(
 export function primitivePropertyInUri(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Property> {
   return keyValuePairInUri(
     value,
     index,
@@ -376,7 +376,7 @@ export function primitivePropertyInUri(
 export function navigationPropertyInUri(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Property> {
   return (
     singleNavPropInJSON(value, index) || collectionNavPropInJSON(value, index)
   );
@@ -385,7 +385,7 @@ export function navigationPropertyInUri(
 export function singleNavPropInJSON(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Property> {
   return keyValuePairInUri(
     value,
     index,
@@ -397,7 +397,7 @@ export function singleNavPropInJSON(
 export function collectionNavPropInJSON(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Property> {
   return keyValuePairInUri(
     value,
     index,
@@ -406,7 +406,7 @@ export function collectionNavPropInJSON(
   );
 }
 
-export function rootExprCol(value: SourceArray, index: number): Lexer.Token {
+export function rootExprCol(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Array> {
   const begin = Lexer.beginArray(value, index);
   if (begin === index) {
     return;
@@ -452,7 +452,7 @@ export function rootExprCol(value: SourceArray, index: number): Lexer.Token {
 export function primitiveLiteralInJSON(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return (
     stringInJSON(value, index) ||
     numberInJSON(value, index) ||
@@ -461,7 +461,7 @@ export function primitiveLiteralInJSON(
   );
 }
 
-export function stringInJSON(value: SourceArray, index: number): Lexer.Token {
+export function stringInJSON(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   let mark = Lexer.quotationMark(value, index);
   if (mark === index) {
     return;
@@ -522,7 +522,7 @@ export function charInJSON(value: SourceArray, index: number): number {
   }
 }
 
-export function numberInJSON(value: SourceArray, index: number): Lexer.Token {
+export function numberInJSON(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const token =
     PrimitiveLiteral.doubleValue(value, index) ||
     PrimitiveLiteral.int64Value(value, index);
@@ -532,7 +532,7 @@ export function numberInJSON(value: SourceArray, index: number): Lexer.Token {
   }
 }
 
-export function booleanInJSON(value: SourceArray, index: number): Lexer.Token {
+export function booleanInJSON(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (Utils.equals(value, index, 'true')) {
     return Lexer.tokenize(
       value,
@@ -553,7 +553,7 @@ export function booleanInJSON(value: SourceArray, index: number): Lexer.Token {
   }
 }
 
-export function nullInJSON(value: SourceArray, index: number): Lexer.Token {
+export function nullInJSON(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (Utils.equals(value, index, 'null')) {
     return Lexer.tokenize(
       value,
@@ -565,7 +565,7 @@ export function nullInJSON(value: SourceArray, index: number): Lexer.Token {
   }
 }
 
-export function arrayOrObject(value: SourceArray, index: number): Lexer.Token {
+export function arrayOrObject(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.ArrayOrObject> {
   const token =
     complexColInUri(value, index) ||
     complexInUri(value, index) ||

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -1,3 +1,4 @@
+import { TokenOfType, TokenTypeValue } from './token';
 import Utils, { SourceArray } from './utils';
 
 export enum TokenType {
@@ -134,7 +135,6 @@ export enum TokenType {
   Crossjoin = 'Crossjoin',
   AllResource = 'AllResource',
   ActionImportCall = 'ActionImportCall',
-  FunctionImportCall = 'FunctionImportCall',
   EntityCollectionFunctionImportCall = 'EntityCollectionFunctionImportCall',
   EntityFunctionImportCall = 'EntityFunctionImportCall',
   ComplexCollectionFunctionImportCall = 'ComplexCollectionFunctionImportCall',
@@ -166,23 +166,25 @@ export enum TokenType {
 export const LexerTokenType = TokenType;
 export type LexerTokenType = TokenType;
 
-export class Token {
+export type MetadataContext = any;
+
+export class Token<T extends TokenType = any> {
   position: number;
   next: number;
-  value: any;
-  type: TokenType;
+  value: TokenTypeValue<T>;
+  type: T;
   /**
    * raw string of token
    */
   raw: string;
-  metadata: any;
+  metadata: MetadataContext;
   constructor(token: {
     position: number;
     next: number;
-    value: any;
-    type: TokenType;
+    value: TokenTypeValue<T>;
+    type: T;
     raw: string;
-    metadata?: any;
+    metadata?: MetadataContext;
   }) {
     this.position = token.position;
     this.next = token.next;
@@ -197,15 +199,15 @@ export class Token {
 
 export type LexerToken = Token;
 
-export function tokenize(
+export function tokenize<T extends TokenType>(
   value: SourceArray,
   index: number,
   next: number,
-  tokenValue: any,
-  tokenType: TokenType,
-  metadataContextContainer?: Token
-): Token {
-  const token = new Token({
+  tokenValue: TokenTypeValue<T>,
+  tokenType: T,
+  metadataContextContainer?: { metadata: MetadataContext }
+): TokenOfType<T> {
+  const token = new Token<T>({
     position: index,
     next,
     value: tokenValue,
@@ -219,9 +221,8 @@ export function tokenize(
   return token;
 }
 
-
-export function clone(token): Token {
-  return new Token({
+export function clone<T extends TokenType>(token: Token<T>): TokenOfType<T> {
+  return new Token<T>({
     position: token.position,
     next: token.next,
     value: token.value,

--- a/src/nameOrIdentifier.ts
+++ b/src/nameOrIdentifier.ts
@@ -1,8 +1,9 @@
 import * as Lexer from './lexer';
 import * as PrimitiveLiteral from './primitiveLiteral';
+import * as Token from './token';
 import Utils, { SourceArray } from './utils';
 
-export function enumeration(value: SourceArray, index: number): Lexer.Token {
+export function enumeration(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Enum> {
   const type = qualifiedEnumTypeName(value, index);
   if (!type) {
     return;
@@ -39,7 +40,7 @@ export function enumeration(value: SourceArray, index: number): Lexer.Token {
     Lexer.TokenType.Enum
   );
 }
-export function enumValue(value: SourceArray, index: number): Lexer.Token {
+export function enumValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.EnumValue> {
   let val = singleEnumValue(value, index);
   if (!val) {
     return;
@@ -70,23 +71,26 @@ export function enumValue(value: SourceArray, index: number): Lexer.Token {
 export function singleEnumValue(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.EnumerationMember> | Lexer.Token<Lexer.TokenType.EnumMemberValue> {
   return enumerationMember(value, index) || enumMemberValue(value, index);
 }
 export function enumMemberValue(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.EnumMemberValue> {
   const token = PrimitiveLiteral.int64Value(value, index);
   if (token) {
-    token.type = Lexer.TokenType.EnumMemberValue;
-    return token;
+    return Lexer.clone({
+      ...token,
+      type: Lexer.TokenType.EnumMemberValue,
+      value: String(token.value)
+    });
   }
 }
 export function singleQualifiedTypeName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.QualifiedEntityTypeName> | Lexer.Token<Lexer.TokenType.QualifiedComplexTypeName> | Lexer.Token<Lexer.TokenType.Identifier> {
   return (
     qualifiedEntityTypeName(value, index) ||
     qualifiedComplexTypeName(value, index) ||
@@ -98,7 +102,7 @@ export function singleQualifiedTypeName(
 export function qualifiedTypeName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.QualifiedEntityTypeName> | Lexer.Token<Lexer.TokenType.Identifier> | Lexer.Token<Lexer.TokenType.QualifiedComplexTypeName> {
   if (Utils.equals(value, index, 'Collection')) {
     const start = index;
     index += 10;
@@ -124,7 +128,9 @@ export function qualifiedTypeName(
     token.position = start;
     token.next = index;
     token.raw = Utils.stringify(value, token.position, token.next);
+    // @ts-expect-error
     token.type = Lexer.TokenType.Collection;
+    // TODO: This if-condition isn't returning anything after doing all this work. Bug?
   } else {
     return singleQualifiedTypeName(value, index);
   }
@@ -132,8 +138,8 @@ export function qualifiedTypeName(
 export function qualifiedEntityTypeName(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.QualifiedEntityTypeName> {
   const start = index;
   const namespaceNext = namespace(value, index);
 
@@ -163,8 +169,8 @@ export function qualifiedEntityTypeName(
 export function qualifiedComplexTypeName(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.QualifiedComplexTypeName> {
   const start = index;
   const namespaceNext = namespace(value, index);
   if (namespaceNext === index || value[namespaceNext] !== 0x2e) {
@@ -193,7 +199,7 @@ export function qualifiedComplexTypeName(
 export function qualifiedTypeDefinitionName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Identifier> {
   const start = index;
   const namespaceNext = namespace(value, index);
   if (namespaceNext === index || value[namespaceNext] !== 0x2e) {
@@ -215,7 +221,7 @@ export function qualifiedTypeDefinitionName(
 export function qualifiedEnumTypeName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Identifier> {
   const start = index;
   const namespaceNext = namespace(value, index);
   if (namespaceNext === index || value[namespaceNext] !== 0x2e) {
@@ -249,11 +255,48 @@ export function namespace(value: SourceArray, index: number): number {
 
   return index - 1;
 }
-export function odataIdentifier(
+
+type ODataIdentifierType =
+  | Lexer.TokenType.ODataIdentifier
+  | Lexer.TokenType.Action
+  | Lexer.TokenType.ActionImport
+  | Lexer.TokenType.ComplexFunction
+  | Lexer.TokenType.ComplexProperty
+  | Lexer.TokenType.ComplexCollectionFunction
+  | Lexer.TokenType.ComplexCollectionFunctionImport
+  | Lexer.TokenType.ComplexCollectionProperty
+  | Lexer.TokenType.ComplexFunctionImport
+  | Lexer.TokenType.ComplexTypeName
+  | Lexer.TokenType.EntityCollectionFunctionImport
+  | Lexer.TokenType.EntityCollectionFunction
+  | Lexer.TokenType.EntityCollectionNavigationProperty
+  | Lexer.TokenType.EntityNavigationProperty
+  | Lexer.TokenType.EntityFunction
+  | Lexer.TokenType.EntityFunctionImport
+  | Lexer.TokenType.EntitySetName
+  | Lexer.TokenType.EntityTypeName
+  | Lexer.TokenType.EnumerationMember
+  | Lexer.TokenType.EnumerationTypeName
+  | Lexer.TokenType.KeyPropertyAlias
+  | Lexer.TokenType.LambdaVariableExpression
+  | Lexer.TokenType.NamespacePart
+  | Lexer.TokenType.ParameterName
+  | Lexer.TokenType.PrimitiveProperty
+  | Lexer.TokenType.SingletonEntity
+  | Lexer.TokenType.StreamProperty
+  | Lexer.TokenType.TermName
+  | Lexer.TokenType.PrimitiveCollectionFunction
+  | Lexer.TokenType.PrimitiveCollectionFunctionImport
+  | Lexer.TokenType.PrimitiveCollectionProperty
+  | Lexer.TokenType.PrimitiveFunction
+  | Lexer.TokenType.PrimitiveFunctionImport
+  | Lexer.TokenType.TypeDefinitionName;
+
+export function odataIdentifier<T extends ODataIdentifierType>(
   value: SourceArray,
   index: number,
-  tokenType?: Lexer.TokenType
-): Lexer.Token {
+  tokenType: T
+): Token.TokenOfType<T> {
   const start = index;
   if (Lexer.identifierLeadingCharacter(value[index])) {
     index++;
@@ -272,18 +315,21 @@ export function odataIdentifier(
       start,
       index,
       { name: Utils.stringify(value, start, index) },
-      tokenType || Lexer.TokenType.ODataIdentifier
+      tokenType
     );
   }
 }
-export function namespacePart(value: SourceArray, index: number): Lexer.Token {
+export function namespacePart(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.NamespacePart> {
   return odataIdentifier(value, index, Lexer.TokenType.NamespacePart);
 }
 export function entitySetName(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntitySetName> {
   const token = odataIdentifier(value, index, Lexer.TokenType.EntitySetName);
   if (!token) {
     return;
@@ -332,14 +378,14 @@ export function entitySetName(
 export function singletonEntity(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.SingletonEntity> {
   return odataIdentifier(value, index, Lexer.TokenType.SingletonEntity);
 }
 export function entityTypeName(
   value: SourceArray,
   index: number,
   schema?: any
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.EntityTypeName> {
   const token = odataIdentifier(value, index, Lexer.TokenType.EntityTypeName);
   if (!token) {
     return;
@@ -359,7 +405,7 @@ export function complexTypeName(
   value: SourceArray,
   index: number,
   schema?: any
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.ComplexTypeName> {
   const token = odataIdentifier(value, index, Lexer.TokenType.ComplexTypeName);
   if (!token) {
     return;
@@ -378,28 +424,31 @@ export function complexTypeName(
 export function typeDefinitionName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.TypeDefinitionName> {
   return odataIdentifier(value, index, Lexer.TokenType.TypeDefinitionName);
 }
 export function enumerationTypeName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.EnumerationTypeName> {
   return odataIdentifier(value, index, Lexer.TokenType.EnumerationTypeName);
 }
 export function enumerationMember(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.EnumerationMember> {
   return odataIdentifier(value, index, Lexer.TokenType.EnumerationMember);
 }
-export function termName(value: SourceArray, index: number): Lexer.Token {
+export function termName(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.TermName> {
   return odataIdentifier(value, index, Lexer.TokenType.TermName);
 }
 export function primitiveTypeName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Identifier> {
   if (!Utils.equals(value, index, 'Edm.')) {
     return;
   }
@@ -484,7 +533,7 @@ const primitiveTypes: string[] = [
 ];
 export function isPrimitiveTypeName(
   type: string,
-  metadataContext?: any
+  metadataContext?: Lexer.MetadataContext
 ): boolean {
   const root = getMetadataRoot(metadataContext);
   const schemas =
@@ -516,7 +565,7 @@ export function isPrimitiveTypeName(
   }
   return primitiveTypes.indexOf(type) >= 0;
 }
-export function getMetadataRoot(metadataContext: any) {
+export function getMetadataRoot(metadataContext: Lexer.MetadataContext) {
   let root = metadataContext;
   while (root.parent) {
     root = root.parent;
@@ -526,13 +575,14 @@ export function getMetadataRoot(metadataContext: any) {
 export function primitiveProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
-  const token = odataIdentifier(
-    value,
-    index,
-    Lexer.TokenType.PrimitiveProperty
-  );
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveProperty> | Lexer.Token<Lexer.TokenType.PrimitiveKeyProperty> {
+  let token: Lexer.Token<Lexer.TokenType.PrimitiveProperty> | Lexer.Token<Lexer.TokenType.PrimitiveKeyProperty> =
+    odataIdentifier(
+      value,
+      index,
+      Lexer.TokenType.PrimitiveProperty
+    );
   if (!token) {
     return;
   }
@@ -554,7 +604,7 @@ export function primitiveProperty(
           metadataContext.key.propertyRefs.filter((it) => it.name === prop.name)
             .length > 0
         ) {
-          token.type = Lexer.TokenType.PrimitiveKeyProperty;
+          token = Lexer.clone({ ...token, type: Lexer.TokenType.PrimitiveKeyProperty });
         }
 
         break;
@@ -571,8 +621,8 @@ export function primitiveProperty(
 export function primitiveKeyProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveKeyProperty> {
   const token = primitiveProperty(value, index, metadataContext);
   if (token && token.type === Lexer.TokenType.PrimitiveKeyProperty) {
     return token;
@@ -581,8 +631,8 @@ export function primitiveKeyProperty(
 export function primitiveNonKeyProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveProperty> {
   const token = primitiveProperty(value, index, metadataContext);
   if (token && token.type === Lexer.TokenType.PrimitiveProperty) {
     return token;
@@ -591,13 +641,14 @@ export function primitiveNonKeyProperty(
 export function primitiveColProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
-  const token = odataIdentifier(
-    value,
-    index,
-    Lexer.TokenType.PrimitiveCollectionProperty
-  );
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveCollectionProperty> | Lexer.Token<Lexer.TokenType.PrimitiveKeyProperty> {
+  let token: Lexer.Token<Lexer.TokenType.PrimitiveCollectionProperty> | Lexer.Token<Lexer.TokenType.PrimitiveKeyProperty> =
+    odataIdentifier(
+      value,
+      index,
+      Lexer.TokenType.PrimitiveCollectionProperty
+    );
   if (!token) {
     return;
   }
@@ -618,7 +669,7 @@ export function primitiveColProperty(
           metadataContext.key.propertyRefs.filter((it) => it.name === prop.name)
             .length > 0
         ) {
-          token.type = Lexer.TokenType.PrimitiveKeyProperty;
+          token = Lexer.clone({ ...token, type: Lexer.TokenType.PrimitiveKeyProperty });
         }
 
         break;
@@ -635,8 +686,8 @@ export function primitiveColProperty(
 export function complexProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ComplexProperty> {
   const token = odataIdentifier(value, index, Lexer.TokenType.ComplexProperty);
   if (!token) {
     return;
@@ -682,8 +733,8 @@ export function complexProperty(
 export function complexColProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ComplexCollectionProperty> {
   const token = odataIdentifier(
     value,
     index,
@@ -733,8 +784,8 @@ export function complexColProperty(
 export function streamProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.StreamProperty> {
   const token = odataIdentifier(value, index, Lexer.TokenType.StreamProperty);
   if (!token) {
     return;
@@ -763,8 +814,8 @@ export function streamProperty(
 export function navigationProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntityNavigationProperty> | Lexer.Token<Lexer.TokenType.EntityCollectionNavigationProperty> {
   return (
     entityNavigationProperty(value, index, metadataContext) ||
     entityColNavigationProperty(value, index, metadataContext)
@@ -773,8 +824,8 @@ export function navigationProperty(
 export function entityNavigationProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntityNavigationProperty> {
   const token = odataIdentifier(
     value,
     index,
@@ -820,8 +871,8 @@ export function entityNavigationProperty(
 export function entityColNavigationProperty(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntityCollectionNavigationProperty> {
   const token = odataIdentifier(
     value,
     index,
@@ -869,8 +920,8 @@ export function action(
   value: SourceArray,
   index: number,
   isCollection?: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.Action> {
   const token = odataIdentifier(value, index, Lexer.TokenType.Action);
   if (!token) {
     return;
@@ -896,8 +947,8 @@ export function action(
 export function actionImport(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ActionImport> {
   const token = odataIdentifier(value, index, Lexer.TokenType.ActionImport);
   if (!token) {
     return;
@@ -913,7 +964,10 @@ export function actionImport(
   return token;
 }
 
-export function odataFunction(value: SourceArray, index: number): Lexer.Token {
+export function odataFunction(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.EntityFunction> | Lexer.Token<Lexer.TokenType.EntityCollectionFunction> | Lexer.Token<Lexer.TokenType.ComplexFunction> | Lexer.Token<Lexer.TokenType.ComplexCollectionFunction> | Lexer.Token<Lexer.TokenType.PrimitiveFunction> | Lexer.Token<Lexer.TokenType.PrimitiveCollectionFunction> {
   return (
     entityFunction(value, index) ||
     entityColFunction(value, index) ||
@@ -924,10 +978,10 @@ export function odataFunction(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function getOperationType(
+export function getOperationType<T extends Lexer.TokenType>(
   operation: string,
-  metadataContext: any,
-  token: Lexer.Token,
+  metadataContext: Lexer.MetadataContext,
+  token: Token.TokenOfType<T>,
   isBoundCollection: boolean,
   isCollection: boolean,
   isPrimitive: boolean,
@@ -1011,8 +1065,8 @@ export function entityFunction(
   value: SourceArray,
   index: number,
   isCollection?: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntityFunction> {
   const token = odataIdentifier(value, index, Lexer.TokenType.EntityFunction);
   if (!token) {
     return;
@@ -1040,8 +1094,8 @@ export function entityColFunction(
   value: SourceArray,
   index: number,
   isCollection?: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntityCollectionFunction> {
   const token = odataIdentifier(
     value,
     index,
@@ -1073,8 +1127,8 @@ export function complexFunction(
   value: SourceArray,
   index: number,
   isCollection?: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ComplexFunction> {
   const token = odataIdentifier(value, index, Lexer.TokenType.ComplexFunction);
   if (!token) {
     return;
@@ -1102,8 +1156,8 @@ export function complexColFunction(
   value: SourceArray,
   index: number,
   isCollection?: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ComplexCollectionFunction> {
   const token = odataIdentifier(
     value,
     index,
@@ -1135,8 +1189,8 @@ export function primitiveFunction(
   value: SourceArray,
   index: number,
   isCollection?: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveFunction> {
   const token = odataIdentifier(
     value,
     index,
@@ -1167,8 +1221,8 @@ export function primitiveColFunction(
   value: SourceArray,
   index: number,
   isCollection?: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveCollectionFunction> {
   const token = odataIdentifier(
     value,
     index,
@@ -1196,10 +1250,10 @@ export function primitiveColFunction(
   return token;
 }
 
-export function getOperationImportType(
+export function getOperationImportType<T extends Lexer.TokenType>(
   operation: string,
-  metadataContext: any,
-  token: Lexer.Token,
+  metadataContext: Lexer.MetadataContext,
+  token: Lexer.Token<T>,
   isCollection?: boolean,
   isPrimitive?: boolean,
   types?: string
@@ -1290,8 +1344,8 @@ export function getOperationImportType(
 export function entityFunctionImport(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntityFunctionImport> {
   const token = odataIdentifier(
     value,
     index,
@@ -1321,8 +1375,8 @@ export function entityFunctionImport(
 export function entityColFunctionImport(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.EntityCollectionFunctionImport> {
   const token = odataIdentifier(
     value,
     index,
@@ -1352,8 +1406,8 @@ export function entityColFunctionImport(
 export function complexFunctionImport(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ComplexFunctionImport> {
   const token = odataIdentifier(
     value,
     index,
@@ -1383,8 +1437,8 @@ export function complexFunctionImport(
 export function complexColFunctionImport(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ComplexCollectionFunctionImport> {
   const token = odataIdentifier(
     value,
     index,
@@ -1414,8 +1468,8 @@ export function complexColFunctionImport(
 export function primitiveFunctionImport(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveFunctionImport> {
   const token = odataIdentifier(
     value,
     index,
@@ -1444,8 +1498,8 @@ export function primitiveFunctionImport(
 export function primitiveColFunctionImport(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PrimitiveCollectionFunctionImport> {
   const token = odataIdentifier(
     value,
     index,

--- a/src/odataUri.ts
+++ b/src/odataUri.ts
@@ -6,8 +6,8 @@ import { SourceArray } from './utils';
 export function odataUri(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ODataUri> {
   let resource = ResourcePath.resourcePath(value, index, metadataContext);
   while (!resource && index < value.length) {
     while (value[++index] !== 0x2f && index < value.length) {}
@@ -36,6 +36,6 @@ export function odataUri(
     index,
     { resource, query },
     Lexer.TokenType.ODataUri,
-    <any>{ metadata: metadataContext }
+    <{ metadata: Lexer.MetadataContext }>{ metadata: metadataContext }
   );
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,11 +5,21 @@ import * as ODataUri from './odataUri';
 import * as PrimitiveLiteral from './primitiveLiteral';
 import * as Query from './query';
 import * as ResourcePath from './resourcePath';
-import { QueryOptionsToken } from './token';
+import * as Token from './token';
+import { SourceArray } from './utils';
 
-export const parserFactory = function(fn) {
-  return function(source, options) {
-    options = options || {};
+interface Options {
+  metadata?: Lexer.MetadataContext;
+}
+
+type ParserFn<T extends Lexer.TokenType> = (
+  value: SourceArray,
+  index: number,
+  metadataContext?: Lexer.MetadataContext
+) => Token.TokenOfType<T> | undefined;
+
+export const parserFactory = function<T extends Lexer.TokenType>(fn: ParserFn<T>) {
+  return function(source: string, options: Options = {}) {
     const raw = new Uint16Array(source.length);
     const pos = 0;
     for (let i = 0; i < source.length; i++) {
@@ -36,46 +46,96 @@ export class Parser {
    * @param source
    * @param options
    */
-  odataUri(source: string, options?: any): Lexer.Token {
+  odataUri(source: string, options?: Options): Lexer.Token<Lexer.TokenType.ODataUri> {
     return parserFactory(ODataUri.odataUri)(source, options);
   }
-  resourcePath(source: string, options?: any): Lexer.Token {
+  resourcePath(source: string, options?: Options): Token.TokenOfType<
+    | Lexer.TokenType.Batch
+    | Lexer.TokenType.Entity
+    | Lexer.TokenType.Metadata
+    | Lexer.TokenType.ResourcePath
+  > {
     return parserFactory(ResourcePath.resourcePath)(source, options);
   }
-  query(source: string, options?: any): QueryOptionsToken {
+  query(source: string, options?: Options): Lexer.Token<Lexer.TokenType.QueryOptions> {
     return parserFactory(Query.queryOptions)(source, options);
   }
-  filter(source: string, options?: any): Lexer.Token {
+  filter(source: string, options?: Options): Token.TokenOfType<
+    | Lexer.TokenType.IsOfExpression
+    | Lexer.TokenType.MethodCallExpression
+    | Lexer.TokenType.NotExpression
+    | Lexer.TokenType.CommonExpression
+    | Lexer.TokenType.BoolParenExpression
+    | Lexer.TokenType.EqualsExpression
+    | Lexer.TokenType.NotEqualsExpression
+    | Lexer.TokenType.LesserThanExpression
+    | Lexer.TokenType.LesserOrEqualsExpression
+    | Lexer.TokenType.GreaterThanExpression
+    | Lexer.TokenType.GreaterOrEqualsExpression
+    | Lexer.TokenType.HasExpression
+    | Lexer.TokenType.AndExpression
+    | Lexer.TokenType.OrExpression
+  > {
     return parserFactory(Expressions.boolCommonExpr)(source, options);
   }
-  keys(source: string, options?: any): Lexer.Token {
+  keys(source: string, options?: Options): Token.TokenOfType<
+    | Lexer.TokenType.SimpleKey
+    | Lexer.TokenType.CompoundKey
+  > {
     return parserFactory(Expressions.keyPredicate)(source, options);
   }
-  literal(source: string, options?: any): Lexer.Token {
+  literal(source: string, options?: Options): Token.TokenOfType<
+    | Lexer.TokenType.Literal
+    | Lexer.TokenType.Enum
+  > {
     return parserFactory(PrimitiveLiteral.primitiveLiteral)(source, options);
   }
-  arrayOrObject(source: string, index?: number): Lexer.Token {
-    return parserFactory(ArrayOrObject.arrayOrObject)(source, index);
+  arrayOrObject(source: string, options?: Options): Lexer.Token<Lexer.TokenType.ArrayOrObject> {
+    return parserFactory(ArrayOrObject.arrayOrObject)(source, options);
   }
 }
 
-export function odataUri(source: string, options?: any): Lexer.Token {
+export function odataUri(source: string, options?: Options): Lexer.Token<Lexer.TokenType.ODataUri> {
   return parserFactory(ODataUri.odataUri)(source, options);
 }
-export function resourcePath(source: string, options?: any): Lexer.Token {
+export function resourcePath(source: string, options?: Options): Token.TokenOfType<
+  | Lexer.TokenType.Batch
+  | Lexer.TokenType.Entity
+  | Lexer.TokenType.Metadata
+  | Lexer.TokenType.ResourcePath
+> {
   return parserFactory(ResourcePath.resourcePath)(source, options);
 }
-export function query(source: string, options?: any): Lexer.Token {
+export function query(source: string, options?: Options): Lexer.Token<Lexer.TokenType.QueryOptions> {
   return parserFactory(Query.queryOptions)(source, options);
 }
-export function filter(source: string, options?: any): Lexer.Token {
+export function filter(source: string, options?: Options): Token.TokenOfType<
+  | Lexer.TokenType.IsOfExpression
+  | Lexer.TokenType.MethodCallExpression
+  | Lexer.TokenType.NotExpression
+  | Lexer.TokenType.CommonExpression
+  | Lexer.TokenType.BoolParenExpression
+  | Lexer.TokenType.EqualsExpression
+  | Lexer.TokenType.NotEqualsExpression
+  | Lexer.TokenType.LesserThanExpression
+  | Lexer.TokenType.LesserOrEqualsExpression
+  | Lexer.TokenType.GreaterThanExpression
+  | Lexer.TokenType.GreaterOrEqualsExpression
+  | Lexer.TokenType.HasExpression
+  | Lexer.TokenType.AndExpression
+  | Lexer.TokenType.OrExpression
+> {
   return parserFactory(Expressions.boolCommonExpr)(source, options);
 }
-export function keys(source: string, options?: any): Lexer.Token {
+export function keys(source: string, options?: Options): Token.TokenOfType<
+  | Lexer.TokenType.SimpleKey
+  | Lexer.TokenType.CompoundKey
+> {
   return parserFactory(Expressions.keyPredicate)(source, options);
 }
-export function literal(source: string, options?: any): Lexer.Token {
+export function literal(source: string, options?: Options): Token.TokenOfType<
+  | Lexer.TokenType.Literal
+  | Lexer.TokenType.Enum
+> {
   return parserFactory(PrimitiveLiteral.primitiveLiteral)(source, options);
 }
-
-export * from './types';

--- a/src/primitiveLiteral.ts
+++ b/src/primitiveLiteral.ts
@@ -1,8 +1,9 @@
+import { PrimitiveTypeEnum } from '@odata/metadata';
 import * as Lexer from './lexer';
 import * as NameOrIdentifier from './nameOrIdentifier';
 import Utils, { SourceArray } from './utils';
 
-export function nullValue(value: SourceArray, index: number): Lexer.Token {
+export function nullValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (Utils.equals(value, index, 'null')) {
     return Lexer.tokenize(
       value,
@@ -13,13 +14,13 @@ export function nullValue(value: SourceArray, index: number): Lexer.Token {
     );
   }
 }
-export function booleanValue(value: SourceArray, index: number): Lexer.Token {
+export function booleanValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (Utils.equals(value, index, 'true')) {
     return Lexer.tokenize(
       value,
       index,
       index + 4,
-      'Edm.Boolean',
+      PrimitiveTypeEnum.Boolean,
       Lexer.TokenType.Literal
     );
   }
@@ -28,12 +29,12 @@ export function booleanValue(value: SourceArray, index: number): Lexer.Token {
       value,
       index,
       index + 5,
-      'Edm.Boolean',
+      PrimitiveTypeEnum.Boolean,
       Lexer.TokenType.Literal
     );
   }
 }
-export function guidValue(value, index): Lexer.Token {
+export function guidValue(value, index): Lexer.Token<Lexer.TokenType.Literal> {
   if (
     Utils.required(value, index, Lexer.HEXDIG, 8, 8) &&
     value[index + 8] === 0x2d &&
@@ -49,12 +50,12 @@ export function guidValue(value, index): Lexer.Token {
       value,
       index,
       index + 36,
-      'Edm.Guid',
+      PrimitiveTypeEnum.Guid,
       Lexer.TokenType.Literal
     );
   }
 }
-export function sbyteValue(value: SourceArray, index: number): Lexer.Token {
+export function sbyteValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const start = index;
   const sign = Lexer.SIGN(value, index);
   if (sign) {
@@ -72,13 +73,13 @@ export function sbyteValue(value: SourceArray, index: number): Lexer.Token {
         value,
         start,
         next,
-        'Edm.SByte',
+        PrimitiveTypeEnum.SByte,
         Lexer.TokenType.Literal
       );
     }
   }
 }
-export function byteValue(value: SourceArray, index: number): Lexer.Token {
+export function byteValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const next = Utils.required(value, index, Lexer.DIGIT, 1, 3);
   if (next) {
     if (Lexer.DIGIT(value[next])) {
@@ -90,13 +91,13 @@ export function byteValue(value: SourceArray, index: number): Lexer.Token {
         value,
         index,
         next,
-        'Edm.Byte',
+        PrimitiveTypeEnum.Byte,
         Lexer.TokenType.Literal
       );
     }
   }
 }
-export function int16Value(value: SourceArray, index: number): Lexer.Token {
+export function int16Value(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const start = index;
   const sign = Lexer.SIGN(value, index);
   if (sign) {
@@ -114,13 +115,13 @@ export function int16Value(value: SourceArray, index: number): Lexer.Token {
         value,
         start,
         next,
-        'Edm.Int16',
+        PrimitiveTypeEnum.Int16,
         Lexer.TokenType.Literal
       );
     }
   }
 }
-export function int32Value(value: SourceArray, index: number): Lexer.Token {
+export function int32Value(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const start = index;
   const sign = Lexer.SIGN(value, index);
   if (sign) {
@@ -138,13 +139,13 @@ export function int32Value(value: SourceArray, index: number): Lexer.Token {
         value,
         start,
         next,
-        'Edm.Int32',
+        PrimitiveTypeEnum.Int32,
         Lexer.TokenType.Literal
       );
     }
   }
 }
-export function int64Value(value: SourceArray, index: number): Lexer.Token {
+export function int64Value(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const start = index;
   const sign = Lexer.SIGN(value, index);
   if (sign) {
@@ -166,13 +167,13 @@ export function int64Value(value: SourceArray, index: number): Lexer.Token {
         value,
         start,
         next,
-        'Edm.Int64',
+        PrimitiveTypeEnum.Int64,
         Lexer.TokenType.Literal
       );
     }
   }
 }
-export function decimalValue(value: SourceArray, index: number): Lexer.Token {
+export function decimalValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const start = index;
   const sign = Lexer.SIGN(value, index);
   if (sign) {
@@ -203,11 +204,11 @@ export function decimalValue(value: SourceArray, index: number): Lexer.Token {
     value,
     start,
     end,
-    'Edm.Decimal',
+    PrimitiveTypeEnum.Decimal,
     Lexer.TokenType.Literal
   );
 }
-export function doubleValue(value: SourceArray, index: number): Lexer.Token {
+export function doubleValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const start = index;
   let end = index;
   const nanInfLen = Lexer.nanInfinity(value, index);
@@ -256,18 +257,18 @@ export function doubleValue(value: SourceArray, index: number): Lexer.Token {
     value,
     start,
     end,
-    'Edm.Double',
+    PrimitiveTypeEnum.Double,
     Lexer.TokenType.Literal
   );
 }
-export function singleValue(value: SourceArray, index: number): Lexer.Token {
+export function singleValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const token = doubleValue(value, index);
   if (token) {
-    token.value = 'Edm.Single';
+    token.value = PrimitiveTypeEnum.Single;
   }
   return token;
 }
-export function stringValue(value: SourceArray, index: number): Lexer.Token {
+export function stringValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   // TODO: handle values with double single quote `THeo''Sun A`
   const start = index;
   let squote = Lexer.SQUOTE(value, start);
@@ -317,12 +318,12 @@ export function stringValue(value: SourceArray, index: number): Lexer.Token {
       value,
       start,
       index,
-      'Edm.String',
+      PrimitiveTypeEnum.String,
       Lexer.TokenType.Literal
     );
   }
 }
-export function durationValue(value: SourceArray, index: number): Lexer.Token {
+export function durationValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (!Utils.equals(value, index, 'duration')) {
     return;
   }
@@ -410,11 +411,11 @@ export function durationValue(value: SourceArray, index: number): Lexer.Token {
     value,
     start,
     end,
-    'Edm.Duration',
+    PrimitiveTypeEnum.Duration,
     Lexer.TokenType.Literal
   );
 }
-export function binaryValue(value: SourceArray, index: number): Lexer.Token {
+export function binaryValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const start = index;
   if (!Utils.equals(value, index, 'binary')) {
     return;
@@ -452,11 +453,11 @@ export function binaryValue(value: SourceArray, index: number): Lexer.Token {
     value,
     start,
     index,
-    'Edm.Binary',
+    PrimitiveTypeEnum.Binary,
     Lexer.TokenType.Literal
   );
 }
-export function dateValue(value: SourceArray, index: number): Lexer.Token {
+export function dateValue(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   const yearNext = Lexer.year(value, index);
   if (yearNext === index || value[yearNext] !== 0x2d) {
     return;
@@ -474,14 +475,14 @@ export function dateValue(value: SourceArray, index: number): Lexer.Token {
     value,
     index,
     dayNext,
-    'Edm.Date',
+    PrimitiveTypeEnum.Date,
     Lexer.TokenType.Literal
   );
 }
 export function dateTimeOffsetValue(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   const yearNext = Lexer.year(value, index);
   if (yearNext === index || value[yearNext] !== 0x2d) {
     return;
@@ -548,11 +549,14 @@ export function dateTimeOffsetValue(
     value,
     index,
     end,
-    'Edm.DateTimeOffset',
+    PrimitiveTypeEnum.DateTimeOffset,
     Lexer.TokenType.Literal
   );
 }
-export function timeOfDayValue(value: SourceArray, index: number): Lexer.Token {
+export function timeOfDayValue(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.Literal> {
   const hourNext = Lexer.hour(value, index);
   let colon = Lexer.COLON(value, hourNext);
   if (hourNext === index || !colon) {
@@ -588,7 +592,7 @@ export function timeOfDayValue(value: SourceArray, index: number): Lexer.Token {
     value,
     index,
     end,
-    'Edm.TimeOfDay',
+    PrimitiveTypeEnum.TimeOfDay,
     Lexer.TokenType.Literal
   );
 }
@@ -597,7 +601,7 @@ export function timeOfDayValue(value: SourceArray, index: number): Lexer.Token {
 export function positionLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   const longitude = doubleValue(value, index);
   if (!longitude) {
     return;
@@ -621,7 +625,10 @@ export function positionLiteral(
     Lexer.TokenType.Literal
   );
 }
-export function pointData(value: SourceArray, index: number): Lexer.Token {
+export function pointData(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.Literal> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -643,21 +650,21 @@ export function pointData(value: SourceArray, index: number): Lexer.Token {
 
   return Lexer.tokenize(value, start, index, position, Lexer.TokenType.Literal);
 }
-export function lineStringData(value: SourceArray, index: number): Lexer.Token {
+export function lineStringData(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   return multiGeoLiteralFactory(value, index, '', positionLiteral);
 }
 
-export function ringLiteral(value: SourceArray, index: number): Lexer.Token {
+export function ringLiteral(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   return multiGeoLiteralFactory(value, index, '', positionLiteral);
   // Within each ringLiteral, the first and last positionLiteral elements MUST be an exact syntactic match to each other.
   // Within the polygonData, the ringLiterals MUST specify their points in appropriate winding order.
   // In order of traversal, points to the left side of the ring are interpreted as being in the polygon.
 }
 
-export function polygonData(value: SourceArray, index: number): Lexer.Token {
+export function polygonData(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   return multiGeoLiteralFactory(value, index, '', ringLiteral);
 }
-export function sridLiteral(value: SourceArray, index: number): Lexer.Token {
+export function sridLiteral(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (!Utils.equals(value, index, 'SRID')) {
     return;
   }
@@ -684,7 +691,7 @@ export function sridLiteral(value: SourceArray, index: number): Lexer.Token {
 
   return Lexer.tokenize(value, start, index, 'SRID', Lexer.TokenType.Literal);
 }
-export function pointLiteral(value: SourceArray, index: number): Lexer.Token {
+export function pointLiteral(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (
     !(
       Utils.equals(value, index, 'Point') ||
@@ -703,7 +710,7 @@ export function pointLiteral(value: SourceArray, index: number): Lexer.Token {
 
   return Lexer.tokenize(value, start, data.next, data, Lexer.TokenType.Literal);
 }
-export function polygonLiteral(value: SourceArray, index: number): Lexer.Token {
+export function polygonLiteral(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   if (
     !(
       Utils.equals(value, index, 'Polygon') ||
@@ -726,13 +733,13 @@ export function polygonLiteral(value: SourceArray, index: number): Lexer.Token {
 export function collectionLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return multiGeoLiteralFactory(value, index, 'Collection', geoLiteral);
 }
 export function lineStringLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   if (!Utils.equals(value, index, 'LineString')) {
     return;
   }
@@ -750,7 +757,7 @@ export function lineStringLiteral(
 export function multiLineStringLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return multiGeoLiteralOptionalFactory(
     value,
     index,
@@ -761,13 +768,13 @@ export function multiLineStringLiteral(
 export function multiPointLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return multiGeoLiteralOptionalFactory(value, index, 'MultiPoint', pointData);
 }
 export function multiPolygonLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return multiGeoLiteralOptionalFactory(
     value,
     index,
@@ -779,15 +786,15 @@ export function multiGeoLiteralFactory(
   value: SourceArray,
   index: number,
   prefix: string,
-  itemLiteral: Function
-): Lexer.Token {
+  itemLiteral: (value: SourceArray, index: number) => Lexer.Token<Lexer.TokenType.Literal>
+): Lexer.Token<Lexer.TokenType.Literal> {
   if (!Utils.equals(value, index, `${prefix}(`)) {
     return;
   }
   const start = index;
   index += prefix.length + 1;
 
-  const items = [];
+  const items: Lexer.Token<Lexer.TokenType.Literal>[] = [];
   let geo = itemLiteral(value, index);
   if (!geo) {
     return;
@@ -828,8 +835,8 @@ export function multiGeoLiteralOptionalFactory(
   value: SourceArray,
   index: number,
   prefix: string,
-  itemLiteral: Function
-): Lexer.Token {
+  itemLiteral: (value: SourceArray, index: number) => Lexer.Token<Lexer.TokenType.Literal>
+): Lexer.Token<Lexer.TokenType.Literal> {
   if (!Utils.equals(value, index, `${prefix}(`)) {
     return;
   }
@@ -878,7 +885,7 @@ export function multiGeoLiteralOptionalFactory(
     Lexer.TokenType.Literal
   );
 }
-export function geoLiteral(value: SourceArray, index: number): Lexer.Token {
+export function geoLiteral(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   return (
     collectionLiteral(value, index) ||
     lineStringLiteral(value, index) ||
@@ -892,50 +899,50 @@ export function geoLiteral(value: SourceArray, index: number): Lexer.Token {
 export function fullPointLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return fullGeoLiteralFactory(value, index, pointLiteral);
 }
 export function fullCollectionLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return fullGeoLiteralFactory(value, index, collectionLiteral);
 }
 export function fullLineStringLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return fullGeoLiteralFactory(value, index, lineStringLiteral);
 }
 export function fullMultiLineStringLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return fullGeoLiteralFactory(value, index, multiLineStringLiteral);
 }
 export function fullMultiPointLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return fullGeoLiteralFactory(value, index, multiPointLiteral);
 }
 export function fullMultiPolygonLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return fullGeoLiteralFactory(value, index, multiPolygonLiteral);
 }
 export function fullPolygonLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return fullGeoLiteralFactory(value, index, polygonLiteral);
 }
 export function fullGeoLiteralFactory(
   value: SourceArray,
   index: number,
-  literal: Function
-): Lexer.Token {
+  literal: (value: SourceArray, index: number) => Lexer.Token<Lexer.TokenType.Literal>
+): Lexer.Token<Lexer.TokenType.Literal> {
   const srid = sridLiteral(value, index);
   if (!srid) {
     return;
@@ -958,7 +965,7 @@ export function fullGeoLiteralFactory(
 export function geographyCollection(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   const prefix = Lexer.geographyPrefix(value, index);
   if (prefix === index) {
     return;
@@ -988,18 +995,18 @@ export function geographyCollection(
     value,
     start,
     index,
-    'Edm.GeographyCollection',
+    PrimitiveTypeEnum.GeographyCollection,
     Lexer.TokenType.Literal
   );
 }
 export function geographyLineString(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeographyLineString',
+    PrimitiveTypeEnum.GeographyLineString,
     Lexer.geographyPrefix,
     fullLineStringLiteral
   );
@@ -1007,11 +1014,11 @@ export function geographyLineString(
 export function geographyMultiLineString(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeographyMultiLineString',
+    PrimitiveTypeEnum.GeographyMultiLineString,
     Lexer.geographyPrefix,
     fullMultiLineStringLiteral
   );
@@ -1019,11 +1026,11 @@ export function geographyMultiLineString(
 export function geographyMultiPoint(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeographyMultiPoint',
+    PrimitiveTypeEnum.GeographyMultiPoint,
     Lexer.geographyPrefix,
     fullMultiPointLiteral
   );
@@ -1031,27 +1038,27 @@ export function geographyMultiPoint(
 export function geographyMultiPolygon(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeographyMultiPolygon',
+    PrimitiveTypeEnum.GeographyMultiPolygon,
     Lexer.geographyPrefix,
     fullMultiPolygonLiteral
   );
 }
-export function geographyPoint(value: SourceArray, index: number): Lexer.Token {
-  return geoLiteralFactory(value, index, 'Edm.GeographyPoint', Lexer.geographyPrefix, fullPointLiteral)
-    || geoLiteralFactory(value, index, 'Edm.GeographyPoint', Lexer.geographyPrefix, pointLiteral);
+export function geographyPoint(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
+  return geoLiteralFactory(value, index, PrimitiveTypeEnum.GeographyPoint, Lexer.geographyPrefix, fullPointLiteral)
+    || geoLiteralFactory(value, index, PrimitiveTypeEnum.GeographyPoint, Lexer.geographyPrefix, pointLiteral);
 }
 export function geographyPolygon(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeographyPolygon',
+    PrimitiveTypeEnum.GeographyPolygon,
     Lexer.geographyPrefix,
     fullPolygonLiteral
   );
@@ -1059,11 +1066,11 @@ export function geographyPolygon(
 export function geometryCollection(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeometryCollection',
+    PrimitiveTypeEnum.GeometryCollection,
     Lexer.geometryPrefix,
     fullCollectionLiteral
   );
@@ -1071,11 +1078,11 @@ export function geometryCollection(
 export function geometryLineString(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeometryLineString',
+    PrimitiveTypeEnum.GeometryLineString,
     Lexer.geometryPrefix,
     fullLineStringLiteral
   );
@@ -1083,11 +1090,11 @@ export function geometryLineString(
 export function geometryMultiLineString(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeometryMultiLineString',
+    PrimitiveTypeEnum.GeometryMultiLineString,
     Lexer.geometryPrefix,
     fullMultiLineStringLiteral
   );
@@ -1095,11 +1102,11 @@ export function geometryMultiLineString(
 export function geometryMultiPoint(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeometryMultiPoint',
+    PrimitiveTypeEnum.GeometryMultiPoint,
     Lexer.geometryPrefix,
     fullMultiPointLiteral
   );
@@ -1107,20 +1114,20 @@ export function geometryMultiPoint(
 export function geometryMultiPolygon(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeometryMultiPolygon',
+    PrimitiveTypeEnum.GeometryMultiPolygon,
     Lexer.geometryPrefix,
     fullMultiPolygonLiteral
   );
 }
-export function geometryPoint(value: SourceArray, index: number): Lexer.Token {
+export function geometryPoint(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeometryPoint',
+    PrimitiveTypeEnum.GeometryPoint,
     Lexer.geometryPrefix,
     fullPointLiteral
   );
@@ -1128,11 +1135,11 @@ export function geometryPoint(value: SourceArray, index: number): Lexer.Token {
 export function geometryPolygon(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> {
   return geoLiteralFactory(
     value,
     index,
-    'Edm.GeometryPolygon',
+    PrimitiveTypeEnum.GeometryPolygon,
     Lexer.geometryPrefix,
     fullPolygonLiteral
   );
@@ -1140,10 +1147,10 @@ export function geometryPolygon(
 export function geoLiteralFactory(
   value: SourceArray,
   index: number,
-  type: string,
-  prefix: Function,
-  literal: Function
-): Lexer.Token {
+  type: PrimitiveTypeEnum,
+  prefix: (value: SourceArray, index: number) => number,
+  literal: (value: SourceArray, index: number) => Lexer.Token<Lexer.TokenType.Literal>
+): Lexer.Token<Lexer.TokenType.Literal> {
   const prefixNext = prefix(value, index);
   if (prefixNext === index) {
     return;
@@ -1175,7 +1182,7 @@ export function geoLiteralFactory(
 export function primitiveLiteral(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Literal> | Lexer.Token<Lexer.TokenType.Enum> {
   return (
     nullValue(value, index) ||
     booleanValue(value, index) ||

--- a/src/query.ts
+++ b/src/query.ts
@@ -2,13 +2,15 @@ import * as Expressions from './expressions';
 import * as Lexer from './lexer';
 import * as NameOrIdentifier from './nameOrIdentifier';
 import * as PrimitiveLiteral from './primitiveLiteral';
+import * as Token from './token';
+import { SelectPathToken, TokenOfType, TokenTypeValue } from './token';
 import Utils, { SourceArray } from './utils';
 
 export function queryOptions(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.QueryOptions> {
   if (value.length <= index) {
     return Lexer.tokenize(
       value,
@@ -53,8 +55,21 @@ export function queryOptions(
 export function queryOption(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+):
+  | Lexer.Token<Lexer.TokenType.Expand>
+  | Lexer.Token<Lexer.TokenType.Filter>
+  | Lexer.Token<Lexer.TokenType.Format>
+  | Lexer.Token<Lexer.TokenType.Id>
+  | Lexer.Token<Lexer.TokenType.InlineCount>
+  | Lexer.Token<Lexer.TokenType.OrderBy>
+  | Lexer.Token<Lexer.TokenType.Search>
+  | Lexer.Token<Lexer.TokenType.Select>
+  | Lexer.Token<Lexer.TokenType.Skip>
+  | Lexer.Token<Lexer.TokenType.SkipToken>
+  | Lexer.Token<Lexer.TokenType.Top>
+  | Lexer.Token<Lexer.TokenType.AliasAndValue>
+  | Lexer.Token<Lexer.TokenType.CustomQueryOption> {
   return (
     systemQueryOption(value, index, metadataContext) ||
     aliasAndValue(value, index) ||
@@ -65,8 +80,19 @@ export function queryOption(
 export function systemQueryOption(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+):
+  | Lexer.Token<Lexer.TokenType.Expand>
+  | Lexer.Token<Lexer.TokenType.Filter>
+  | Lexer.Token<Lexer.TokenType.Format>
+  | Lexer.Token<Lexer.TokenType.Id>
+  | Lexer.Token<Lexer.TokenType.InlineCount>
+  | Lexer.Token<Lexer.TokenType.OrderBy>
+  | Lexer.Token<Lexer.TokenType.Search>
+  | Lexer.Token<Lexer.TokenType.Select>
+  | Lexer.Token<Lexer.TokenType.Skip>
+  | Lexer.Token<Lexer.TokenType.SkipToken>
+  | Lexer.Token<Lexer.TokenType.Top> {
   return (
     expand(value, index, metadataContext) ||
     filter(value, index) ||
@@ -85,8 +111,8 @@ export function systemQueryOption(
 export function customQueryOption(
   value: SourceArray,
   index: number
-): Lexer.Token {
-  const key = NameOrIdentifier.odataIdentifier(value, index);
+): Lexer.Token<Lexer.TokenType.CustomQueryOption> {
+  const key = NameOrIdentifier.odataIdentifier(value, index, Lexer.TokenType.ODataIdentifier);
   if (!key) {
     return;
   }
@@ -118,7 +144,10 @@ export function customQueryOption(
   );
 }
 
-export function id(value: SourceArray, index: number): Lexer.Token {
+export function id(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.Id> {
   const start = index;
   if (Utils.equals(value, index, '%24id')) {
     index += 5;
@@ -153,8 +182,8 @@ export function id(value: SourceArray, index: number): Lexer.Token {
 export function expand(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.Expand> {
   const start = index;
   if (Utils.equals(value, index, '%24expand')) {
     index += 9;
@@ -199,8 +228,8 @@ export function expand(
 export function expandItem(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ExpandItem> {
   const start = index;
   const star = Lexer.STAR(value, index);
   if (star) {
@@ -258,7 +287,7 @@ export function expandItem(
   }
   index = path.next;
 
-  const tokenValue: any = { path };
+  const tokenValue: Token.ExpandItemToken['value'] = { path };
 
   const ref = Expressions.refExpr(value, index);
   if (ref) {
@@ -274,7 +303,7 @@ export function expandItem(
         return;
       }
 
-      const refOptions = [];
+      const refOptions: NonNullable<Token.ExpandItemToken['value']['options']> = [];
       while (option) {
         refOptions.push(option);
         index = option.next;
@@ -390,14 +419,20 @@ export function expandItem(
 export function expandCountOption(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Filter> | Lexer.Token<Lexer.TokenType.Search> {
   return filter(value, index) || search(value, index);
 }
 
 export function expandRefOption(
   value: SourceArray,
   index: number
-): Lexer.Token {
+):
+  | Lexer.Token<Lexer.TokenType.Filter>
+  | Lexer.Token<Lexer.TokenType.Search>
+  | Lexer.Token<Lexer.TokenType.OrderBy>
+  | Lexer.Token<Lexer.TokenType.Skip>
+  | Lexer.Token<Lexer.TokenType.Top>
+  | Lexer.Token<Lexer.TokenType.InlineCount> {
   return (
     expandCountOption(value, index) ||
     orderby(value, index) ||
@@ -407,7 +442,19 @@ export function expandRefOption(
   );
 }
 
-export function expandOption(value: SourceArray, index: number): Lexer.Token {
+export function expandOption(
+  value: SourceArray,
+  index: number
+):
+  | Lexer.Token<Lexer.TokenType.Filter>
+  | Lexer.Token<Lexer.TokenType.Search>
+  | Lexer.Token<Lexer.TokenType.OrderBy>
+  | Lexer.Token<Lexer.TokenType.Skip>
+  | Lexer.Token<Lexer.TokenType.Top>
+  | Lexer.Token<Lexer.TokenType.InlineCount>
+  | Lexer.Token<Lexer.TokenType.Select>
+  | Lexer.Token<Lexer.TokenType.Expand>
+  | Lexer.Token<Lexer.TokenType.Levels> {
   return (
     expandRefOption(value, index) ||
     select(value, index) ||
@@ -419,8 +466,8 @@ export function expandOption(value: SourceArray, index: number): Lexer.Token {
 export function expandPath(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ExpandPath> {
   const start = index;
   const path = [];
 
@@ -500,7 +547,7 @@ export function expandPath(
   return Lexer.tokenize(value, start, index, path, Lexer.TokenType.ExpandPath);
 }
 
-export function search(value: SourceArray, index: number): Lexer.Token {
+export function search(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Search> {
   const start = index;
   if (Utils.equals(value, index, '%24search')) {
     index += 9;
@@ -525,50 +572,78 @@ export function search(value: SourceArray, index: number): Lexer.Token {
   return Lexer.tokenize(value, start, index, expr, Lexer.TokenType.Search);
 }
 
-export function searchExpr(value: SourceArray, index: number): Lexer.Token {
-  const token = searchParenExpr(value, index) || searchTerm(value, index);
+export function searchExpr(
+  value: SourceArray,
+  index: number
+):
+  | Lexer.Token<Lexer.TokenType.SearchAndExpression>
+  | Lexer.Token<Lexer.TokenType.SearchOrExpression>
+  | Lexer.Token<Lexer.TokenType.SearchNotExpression>
+  | Lexer.Token<Lexer.TokenType.SearchParenExpression>
+  | Lexer.Token<Lexer.TokenType.SearchPhrase>
+  | Lexer.Token<Lexer.TokenType.SearchTerm>
+  | Lexer.Token<Lexer.TokenType.SearchWord> {
+  let token: TokenOfType<
+    | Lexer.TokenType.SearchAndExpression
+    | Lexer.TokenType.SearchOrExpression
+    | Lexer.TokenType.SearchNotExpression
+    | Lexer.TokenType.SearchParenExpression
+    | Lexer.TokenType.SearchPhrase
+    | Lexer.TokenType.SearchTerm
+    | Lexer.TokenType.SearchWord
+  > = searchParenExpr(value, index) || searchTerm(value, index);
 
   if (!token) {
     return;
   }
-  const start = index;
   index = token.next;
 
   const expr = searchAndExpr(value, index) || searchOrExpr(value, index);
 
   if (expr) {
     const left = Lexer.clone(token);
-    token.next = expr.value.next;
-    token.value = {
-      left,
-      right: expr.value
-    };
-    token.type = expr.type;
-    token.raw = Utils.stringify(value, token.position, token.next);
+    token = new Lexer.Token({
+      ...token,
+      type: expr.type,
+      value: { left, right: expr.value },
+      next: expr.value.next,
+      raw: Utils.stringify(value, token.position, token.next)
+    });
 
     if (
       token.type === Lexer.TokenType.SearchAndExpression &&
       token.value.right.type === Lexer.TokenType.SearchOrExpression
     ) {
-      token.value.left = Lexer.tokenize(
-        value,
-        token.value.left.position,
-        token.value.right.value.left.next,
-        {
-          left: token.value.left,
-          right: token.value.right.value.left
-        },
-        token.type
-      );
-      token.type = token.value.right.type;
-      token.value.right = token.value.right.value.right;
+      token = Lexer.clone({
+        ...token,
+        type: token.value.right.type,
+        value: {
+          left: Lexer.tokenize(
+            value,
+            token.value.left.position,
+            token.value.right.value.left.next,
+            {
+              left: token.value.left,
+              right: token.value.right.value.left
+            },
+            token.type
+          ),
+          right: token.value.right.value.right
+        }
+      });
     }
   }
 
   return token;
 }
 
-export function searchTerm(value: SourceArray, index: number): Lexer.Token {
+export function searchTerm(
+  value: SourceArray,
+  index: number
+):
+  | Lexer.Token<Lexer.TokenType.SearchNotExpression>
+  | Lexer.Token<Lexer.TokenType.SearchPhrase>
+  | Lexer.Token<Lexer.TokenType.SearchWord> {
   return (
     searchNotExpr(value, index) ||
     searchPhrase(value, index) ||
@@ -576,7 +651,7 @@ export function searchTerm(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function searchNotExpr(value: SourceArray, index: number): Lexer.Token {
+export function searchNotExpr(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.SearchNotExpression> {
   let rws = Lexer.RWS(value, index);
   if (!Utils.equals(value, rws, 'NOT')) {
     return;
@@ -603,7 +678,20 @@ export function searchNotExpr(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function searchOrExpr(value: SourceArray, index: number): Lexer.Token {
+interface InternalSearchAndOrExpression<
+  T extends Lexer.TokenType.SearchAndExpression | Lexer.TokenType.SearchOrExpression
+> {
+  type: T;
+  value: TokenTypeValue<T>['right'];
+  position: number;
+  next: number;
+  raw: string;
+}
+
+export function searchOrExpr(
+  value: SourceArray,
+  index: number
+): InternalSearchAndOrExpression<Lexer.TokenType.SearchOrExpression> {
   let rws = Lexer.RWS(value, index);
   if (rws === index || !Utils.equals(value, rws, 'OR')) {
     return;
@@ -621,16 +709,19 @@ export function searchOrExpr(value: SourceArray, index: number): Lexer.Token {
   }
   index = token.next;
 
-  return Lexer.tokenize(
-    value,
-    start,
-    index,
-    token,
-    Lexer.TokenType.SearchOrExpression
-  );
+  return {
+    type: Lexer.TokenType.SearchOrExpression,
+    value: token,
+    position: start,
+    next: index,
+    raw: Utils.stringify(value, start, index)
+  };
 }
 
-export function searchAndExpr(value: SourceArray, index: number): Lexer.Token {
+export function searchAndExpr(
+  value: SourceArray,
+  index: number
+): InternalSearchAndOrExpression<Lexer.TokenType.SearchAndExpression> {
   let rws = Lexer.RWS(value, index);
   if (rws === index || !Utils.equals(value, rws, 'AND')) {
     return;
@@ -648,16 +739,16 @@ export function searchAndExpr(value: SourceArray, index: number): Lexer.Token {
   }
   index = token.next;
 
-  return Lexer.tokenize(
-    value,
-    start,
-    index,
-    token,
-    Lexer.TokenType.SearchAndExpression
-  );
+  return {
+    type: Lexer.TokenType.SearchAndExpression,
+    value: token,
+    position: start,
+    next: index,
+    raw: Utils.stringify(value, start, index)
+  };
 }
 
-export function searchPhrase(value: SourceArray, index: number): Lexer.Token {
+export function searchPhrase(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.SearchPhrase> {
   let mark = Lexer.quotationMark(value, index);
   if (mark === index) {
     return;
@@ -692,7 +783,7 @@ export function searchPhrase(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function searchWord(value: SourceArray, index: number): Lexer.Token {
+export function searchWord(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.SearchWord> {
   const next = Utils.required(value, index, Lexer.ALPHA, 1);
   if (!next) {
     return;
@@ -714,7 +805,7 @@ export function searchWord(value: SourceArray, index: number): Lexer.Token {
 export function searchParenExpr(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.SearchParenExpression> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -745,7 +836,7 @@ export function searchParenExpr(
   );
 }
 
-export function levels(value: SourceArray, index: number): Lexer.Token {
+export function levels(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Levels> {
   const start = index;
   if (Utils.equals(value, index, '%24levels')) {
     index += 9;
@@ -777,7 +868,7 @@ export function levels(value: SourceArray, index: number): Lexer.Token {
   return Lexer.tokenize(value, start, index, level, Lexer.TokenType.Levels);
 }
 
-export function filter(value: SourceArray, index: number): Lexer.Token {
+export function filter(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Filter> {
   const start = index;
   if (Utils.equals(value, index, '%24filter')) {
     index += 9;
@@ -802,7 +893,7 @@ export function filter(value: SourceArray, index: number): Lexer.Token {
   return Lexer.tokenize(value, start, index, expr, Lexer.TokenType.Filter);
 }
 
-export function orderby(value: SourceArray, index: number): Lexer.Token {
+export function orderby(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.OrderBy> {
   const start = index;
   if (Utils.equals(value, index, '%24orderby')) {
     index += 10;
@@ -854,7 +945,7 @@ export function orderby(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function orderbyItem(value: SourceArray, index: number): Lexer.Token {
+export function orderbyItem(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.OrderByItem> {
   const expr = Expressions.commonExpr(value, index);
   if (!expr) {
     return;
@@ -885,7 +976,7 @@ export function orderbyItem(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function skip(value: SourceArray, index: number): Lexer.Token {
+export function skip(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Skip> {
   const start = index;
   if (Utils.equals(value, index, '%24skip')) {
     index += 7;
@@ -910,7 +1001,7 @@ export function skip(value: SourceArray, index: number): Lexer.Token {
   return Lexer.tokenize(value, start, index, token, Lexer.TokenType.Skip);
 }
 
-export function top(value: SourceArray, index: number): Lexer.Token {
+export function top(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Top> {
   const start = index;
   if (Utils.equals(value, index, '%24top')) {
     index += 6;
@@ -935,7 +1026,7 @@ export function top(value: SourceArray, index: number): Lexer.Token {
   return Lexer.tokenize(value, start, index, token, Lexer.TokenType.Top);
 }
 
-export function format(value: SourceArray, index: number): Lexer.Token {
+export function format(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Format> {
   const start = index;
   if (Utils.equals(value, index, '%24format')) {
     index += 9;
@@ -980,7 +1071,7 @@ export function format(value: SourceArray, index: number): Lexer.Token {
   }
 }
 
-export function inlinecount(value: SourceArray, index: number): Lexer.Token {
+export function inlinecount(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.InlineCount> {
   const start = index;
   if (Utils.equals(value, index, '%24count')) {
     index += 8;
@@ -1011,7 +1102,7 @@ export function inlinecount(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function select(value: SourceArray, index: number): Lexer.Token {
+export function select(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.Select> {
   const start = index;
   if (Utils.equals(value, index, '%24select')) {
     index += 9;
@@ -1055,7 +1146,10 @@ export function select(value: SourceArray, index: number): Lexer.Token {
   return Lexer.tokenize(value, start, index, { items }, Lexer.TokenType.Select);
 }
 
-export function selectItem(value: SourceArray, index: number): Lexer.Token {
+export function selectItem(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.SelectItem> {
   const start = index;
   let item;
   const op = allOperationsInSchema(value, index);
@@ -1114,7 +1208,17 @@ export function allOperationsInSchema(
   return index;
 }
 
-export function selectProperty(value: SourceArray, index: number): Lexer.Token {
+export function selectProperty(
+  value: SourceArray,
+  index: number
+):
+  | Lexer.Token<Lexer.TokenType.SelectPath>
+  | Lexer.Token<Lexer.TokenType.PrimitiveProperty>
+  | Lexer.Token<Lexer.TokenType.PrimitiveKeyProperty>
+  | Lexer.Token<Lexer.TokenType.PrimitiveCollectionProperty>
+  | Lexer.Token<Lexer.TokenType.PrimitiveKeyProperty>
+  | Lexer.Token<Lexer.TokenType.EntityNavigationProperty>
+  | Lexer.Token<Lexer.TokenType.EntityCollectionNavigationProperty> {
   const token =
     selectPath(value, index) ||
     NameOrIdentifier.primitiveProperty(value, index) ||
@@ -1144,7 +1248,7 @@ export function selectProperty(value: SourceArray, index: number): Lexer.Token {
   return token;
 }
 
-export function selectPath(value: SourceArray, index: number): Lexer.Token {
+export function selectPath(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.SelectPath> {
   const token =
     NameOrIdentifier.complexProperty(value, index) ||
     NameOrIdentifier.complexColProperty(value, index);
@@ -1155,7 +1259,7 @@ export function selectPath(value: SourceArray, index: number): Lexer.Token {
   const start = index;
   index = token.next;
 
-  let tokenValue: any = token;
+  let tokenValue: SelectPathToken['value'] = token;
   if (value[index] === 0x2f) {
     const name = NameOrIdentifier.qualifiedComplexTypeName(value, index + 1);
     if (name) {
@@ -1176,7 +1280,7 @@ export function selectPath(value: SourceArray, index: number): Lexer.Token {
 export function qualifiedActionName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Action> {
   const namespaceNext = NameOrIdentifier.namespace(value, index);
   if (namespaceNext === index || value[namespaceNext] !== 0x2e) {
     return;
@@ -1188,7 +1292,9 @@ export function qualifiedActionName(
   if (!action) {
     return;
   }
-  action.value.namespace = Utils.stringify(value, start, namespaceNext);
+  if (!(action.value instanceof Lexer.Token)) {
+    action.value.namespace = Utils.stringify(value, start, namespaceNext);
+  }
 
   return Lexer.tokenize(
     value,
@@ -1202,7 +1308,7 @@ export function qualifiedActionName(
 export function qualifiedFunctionName(
   value: SourceArray,
   index: number
-): Lexer.Token {
+): Lexer.Token<Lexer.TokenType.Function> {
   const namespaceNext = NameOrIdentifier.namespace(value, index);
   if (namespaceNext === index || value[namespaceNext] !== 0x2e) {
     return;
@@ -1216,12 +1322,11 @@ export function qualifiedFunctionName(
   }
   fn.value.namespace = Utils.stringify(value, start, namespaceNext);
   index = fn.next;
-  const tokenValue: any = { name: fn };
+  const tokenValue: Token.FunctionToken['value'] = { name: fn, parameters: [] };
 
   const open = Lexer.OPEN(value, index);
   if (open) {
     index = open;
-    tokenValue.parameters = [];
     const param = Expressions.parameterName(value, index);
     if (!param) {
       return;
@@ -1259,7 +1364,7 @@ export function qualifiedFunctionName(
   );
 }
 
-export function skiptoken(value: SourceArray, index: number): Lexer.Token {
+export function skiptoken(value: SourceArray, index: number): Lexer.Token<Lexer.TokenType.SkipToken> {
   const start = index;
   if (Utils.equals(value, index, '%24skiptoken')) {
     index += 12;
@@ -1295,7 +1400,10 @@ export function skiptoken(value: SourceArray, index: number): Lexer.Token {
   );
 }
 
-export function aliasAndValue(value: SourceArray, index: number): Lexer.Token {
+export function aliasAndValue(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.AliasAndValue> {
   const alias = Expressions.parameterAlias(value, index);
   if (!alias) {
     return;

--- a/src/resourcePath.ts
+++ b/src/resourcePath.ts
@@ -2,13 +2,19 @@ import * as Expressions from './expressions';
 import * as Lexer from './lexer';
 import * as NameOrIdentifier from './nameOrIdentifier';
 import * as PrimitiveLiteral from './primitiveLiteral';
+import * as Token from './token';
 import Utils, { SourceArray } from './utils';
 
 export function resourcePath(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Token.TokenOfType<
+  | Lexer.TokenType.Batch
+  | Lexer.TokenType.Entity
+  | Lexer.TokenType.Metadata
+  | Lexer.TokenType.ResourcePath
+> {
   if (value[index] === 0x2f) {
     index++;
   }
@@ -33,7 +39,15 @@ export function resourcePath(
   }
   const start = index;
   index = resource.next;
-  let navigation: Lexer.Token;
+  let navigation:
+    | Lexer.Token<Lexer.TokenType.CollectionNavigation>
+    | Lexer.Token<Lexer.TokenType.SingleNavigation>
+    | Lexer.Token<Lexer.TokenType.BoundOperation>
+    | Lexer.Token<Lexer.TokenType.RefExpression>
+    | Lexer.Token<Lexer.TokenType.ValueExpression>
+    | Lexer.Token<Lexer.TokenType.CountExpression>
+    | Lexer.Token<Lexer.TokenType.BoundOperation>
+    | Lexer.Token<Lexer.TokenType.ComplexPath>;
 
   switch (resource.type) {
     case Lexer.TokenType.EntitySetName:
@@ -111,12 +125,15 @@ export function resourcePath(
       index,
       { resource, navigation },
       Lexer.TokenType.ResourcePath,
-      navigation || <any>{ metadata: metadataContext }
+      navigation || { metadata: metadataContext }
     );
   }
 }
 
-export function batch(value: SourceArray, index: number): Lexer.Token {
+export function batch(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.Batch> {
   if (Utils.equals(value, index, '$batch')) {
     return Lexer.tokenize(
       value,
@@ -131,8 +148,8 @@ export function batch(value: SourceArray, index: number): Lexer.Token {
 export function entity(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.Entity> {
   if (Utils.equals(value, index, '$entity')) {
     const start = index;
     index += 7;
@@ -160,7 +177,10 @@ export function entity(
   }
 }
 
-export function metadata(value: SourceArray, index: number): Lexer.Token {
+export function metadata(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.Metadata> {
   if (Utils.equals(value, index, '$metadata')) {
     return Lexer.tokenize(
       value,
@@ -175,8 +195,8 @@ export function metadata(value: SourceArray, index: number): Lexer.Token {
 export function collectionNavigation(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.CollectionNavigation> {
   const start = index;
   let name;
   if (value[index] === 0x2f) {
@@ -214,8 +234,8 @@ export function collectionNavigation(
 export function collectionNavigationPath(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Token.CollectionNavigationToken['value']['path'] {
   const start = index;
   const token =
     collectionPath(value, index, metadataContext) ||
@@ -226,7 +246,7 @@ export function collectionNavigationPath(
 
   const predicate = Expressions.keyPredicate(value, index, metadataContext);
   if (predicate) {
-    let tokenValue: any = { predicate };
+    let tokenValue: Token.CollectionNavigationPathToken['value'] = { predicate };
     index = predicate.next;
 
     const navigation = singleNavigation(value, index, metadataContext);
@@ -241,7 +261,7 @@ export function collectionNavigationPath(
       index,
       tokenValue,
       Lexer.TokenType.CollectionNavigationPath,
-      navigation || <any>{ metadata: metadataContext }
+      navigation || { metadata: metadataContext }
     );
   }
 }
@@ -249,9 +269,18 @@ export function collectionNavigationPath(
 export function singleNavigation(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
-  let token =
+  metadataContext?: Lexer.MetadataContext
+):
+  | Lexer.Token<Lexer.TokenType.SingleNavigation>
+  | Lexer.Token<Lexer.TokenType.BoundOperation>
+  | Lexer.Token<Lexer.TokenType.RefExpression>
+  | Lexer.Token<Lexer.TokenType.ValueExpression> {
+  let token:
+    | Lexer.Token<Lexer.TokenType.SingleNavigation>
+    | Lexer.Token<Lexer.TokenType.BoundOperation>
+    | Lexer.Token<Lexer.TokenType.RefExpression>
+    | Lexer.Token<Lexer.TokenType.ValueExpression>
+    | Lexer.Token<Lexer.TokenType.PropertyPath> =
     boundOperation(value, index, false, metadataContext) ||
     Expressions.refExpr(value, index) ||
     Expressions.valueExpr(value, index);
@@ -299,8 +328,8 @@ export function singleNavigation(
 export function propertyPath(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.PropertyPath> {
   const token =
     NameOrIdentifier.entityColNavigationProperty(
       value,
@@ -370,8 +399,8 @@ export function propertyPath(
 export function collectionPath(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.CountExpression> | Lexer.Token<Lexer.TokenType.BoundOperation> {
   return (
     Expressions.countExpr(value, index) ||
     boundOperation(value, index, true, metadataContext)
@@ -381,8 +410,8 @@ export function collectionPath(
 export function singlePath(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ValueExpression> | Lexer.Token<Lexer.TokenType.BoundOperation> {
   return (
     Expressions.valueExpr(value, index) ||
     boundOperation(value, index, false, metadataContext)
@@ -392,8 +421,8 @@ export function singlePath(
 export function complexPath(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ComplexPath> {
   const start = index;
   let name, token;
   if (value[index] === 0x2f) {
@@ -435,8 +464,8 @@ export function boundOperation(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundOperation> {
   if (value[index] !== 0x2f) {
     return;
   }
@@ -522,8 +551,8 @@ export function boundActionCall(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundActionCall> {
   const namespaceNext = NameOrIdentifier.namespace(value, index);
   if (namespaceNext === index) {
     return;
@@ -545,7 +574,9 @@ export function boundActionCall(
   if (!action) {
     return;
   }
-  action.value.namespace = Utils.stringify(value, start, namespaceNext);
+  if (!(action.value instanceof Lexer.Token)) {
+    action.value.namespace = Utils.stringify(value, start, namespaceNext);
+  }
 
   return Lexer.tokenize(
     value,
@@ -557,14 +588,26 @@ export function boundActionCall(
   );
 }
 
-export function boundFunctionCall(
+export function boundFunctionCall<T extends
+  | Lexer.TokenType.BoundEntityFunctionCall
+  | Lexer.TokenType.BoundEntityCollectionFunctionCall
+  | Lexer.TokenType.BoundComplexFunctionCall
+  | Lexer.TokenType.BoundComplexCollectionFunctionCall
+  | Lexer.TokenType.BoundPrimitiveFunctionCall
+  | Lexer.TokenType.BoundPrimitiveCollectionFunctionCall
+>(
   value: SourceArray,
   index: number,
-  odataFunction: Function,
-  tokenType: Lexer.TokenType,
+  odataFunction: (
+    value: SourceArray,
+    index: number,
+    isCollection?: boolean,
+    metadataContext?: Lexer.MetadataContext
+  ) => Token.TokenOfType<T>['value']['call'],
+  tokenType: T,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Token.TokenOfType<T> {
   const namespaceNext = NameOrIdentifier.namespace(value, index);
   if (namespaceNext === index) {
     return;
@@ -590,6 +633,7 @@ export function boundFunctionCall(
   }
   index = params.next;
 
+  // @ts-expect-error -- TODO: fix `tokenType` and `call` types not aligning here (even though they do in practice)
   return Lexer.tokenize(value, start, index, { call, params }, tokenType, call);
 }
 
@@ -597,8 +641,8 @@ export function boundEntityFuncCall(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundEntityFunctionCall> {
   return boundFunctionCall(
     value,
     index,
@@ -612,8 +656,8 @@ export function boundEntityColFuncCall(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundEntityCollectionFunctionCall> {
   return boundFunctionCall(
     value,
     index,
@@ -627,8 +671,8 @@ export function boundComplexFuncCall(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundComplexFunctionCall> {
   return boundFunctionCall(
     value,
     index,
@@ -642,8 +686,8 @@ export function boundComplexColFuncCall(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundComplexCollectionFunctionCall> {
   return boundFunctionCall(
     value,
     index,
@@ -657,8 +701,8 @@ export function boundPrimitiveFuncCall(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundPrimitiveFunctionCall> {
   return boundFunctionCall(
     value,
     index,
@@ -672,8 +716,8 @@ export function boundPrimitiveColFuncCall(
   value: SourceArray,
   index: number,
   isCollection: boolean,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.BoundPrimitiveCollectionFunctionCall> {
   return boundFunctionCall(
     value,
     index,
@@ -687,8 +731,8 @@ export function boundPrimitiveColFuncCall(
 export function actionImportCall(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.ActionImportCall> {
   const action = NameOrIdentifier.actionImport(value, index, metadataContext);
   if (action) {
     return Lexer.tokenize(
@@ -705,8 +749,14 @@ export function actionImportCall(
 export function functionImportCall(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+):
+  | Lexer.Token<Lexer.TokenType.EntityFunctionImportCall>
+  | Lexer.Token<Lexer.TokenType.EntityCollectionFunctionImportCall>
+  | Lexer.Token<Lexer.TokenType.ComplexFunctionImportCall>
+  | Lexer.Token<Lexer.TokenType.ComplexCollectionFunctionImportCall>
+  | Lexer.Token<Lexer.TokenType.PrimitiveFunctionImportCall>
+  | Lexer.Token<Lexer.TokenType.PrimitiveCollectionFunctionImportCall> {
   const fnImport =
     NameOrIdentifier.entityFunctionImport(value, index, metadataContext) ||
     NameOrIdentifier.entityColFunctionImport(value, index, metadataContext) ||
@@ -731,8 +781,9 @@ export function functionImportCall(
     value,
     start,
     index,
+    // @ts-expect-error -- TODO: fix `tokenType` and `import` types not aligning here (even though they do in practice)
     { import: fnImport, params: params.value },
-    <Lexer.TokenType>`${fnImport.type}Call`,
+    Lexer.TokenType[`${fnImport.type}Call`],
     fnImport
   );
 }
@@ -740,8 +791,8 @@ export function functionImportCall(
 export function functionParameters(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.FunctionParameters> {
   const open = Lexer.OPEN(value, index);
   if (!open) {
     return;
@@ -785,8 +836,8 @@ export function functionParameters(
 export function functionParameter(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.FunctionParameter> {
   const name = Expressions.parameterName(value, index);
   if (!name) {
     return;
@@ -821,8 +872,8 @@ export function functionParameter(
 export function crossjoin(
   value: SourceArray,
   index: number,
-  metadataContext?: any
-): Lexer.Token {
+  metadataContext?: Lexer.MetadataContext
+): Lexer.Token<Lexer.TokenType.Crossjoin> {
   if (!Utils.equals(value, index, '$crossjoin')) {
     return;
   }
@@ -871,7 +922,10 @@ export function crossjoin(
   );
 }
 
-export function all(value: SourceArray, index: number): Lexer.Token {
+export function all(
+  value: SourceArray,
+  index: number
+): Lexer.Token<Lexer.TokenType.AllResource> {
   if (Utils.equals(value, index, '$all')) {
     return Lexer.tokenize(
       value,

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,91 +1,1556 @@
 import { PrimitiveTypeEnum } from '@odata/metadata';
 import { Token, TokenType } from './lexer';
 
-export interface QueryOptionsToken extends Token {
+type NamedValue = { name: string };
+
+type NamespacedNamedValue = { name: string; namespace?: string };
+
+type LeftRightExpressionValue<L, R> = { left: L; right: R };
+
+type LeftRightExpressionTokenValue =
+  | Token<TokenType.ArrayOrObject>
+  | Token<TokenType.RootExpression>
+  | Token<TokenType.FirstMemberExpression>
+  | Token<TokenType.NegateExpression>
+  | Token<TokenType.ParenExpression>
+  | Token<TokenType.CastExpression>
+  | Token<TokenType.Literal>
+  | Token<TokenType.Enum>
+  | Token<TokenType.Identifier>
+  | Token<TokenType.IsOfExpression>
+  | Token<TokenType.FunctionExpression>
+  | Token<TokenType.ParameterAlias>
+  | Token<TokenType.MethodCallExpression>
+  | Token<TokenType.NotExpression>
+  | Token<TokenType.CommonExpression>
+  | Token<TokenType.BoolParenExpression>
+  | Token<TokenType.EqualsExpression>
+  | Token<TokenType.NotEqualsExpression>
+  | Token<TokenType.LesserThanExpression>
+  | Token<TokenType.LesserOrEqualsExpression>
+  | Token<TokenType.GreaterThanExpression>
+  | Token<TokenType.GreaterOrEqualsExpression>
+  | Token<TokenType.HasExpression>
+  | Token<TokenType.AndExpression>
+  | Token<TokenType.OrExpression>
+  | Token<TokenType.AddExpression>
+  | Token<TokenType.SubExpression>
+  | Token<TokenType.MulExpression>
+  | Token<TokenType.DivExpression>
+  | Token<TokenType.ModExpression>;
+
+type SystemQueryOption =
+  | Token<TokenType.Expand>
+  | Token<TokenType.Filter>
+  | Token<TokenType.Format>
+  | Token<TokenType.Id>
+  | Token<TokenType.InlineCount>
+  | Token<TokenType.OrderBy>
+  | Token<TokenType.Search>
+  | Token<TokenType.Select>
+  | Token<TokenType.Skip>
+  | Token<TokenType.SkipToken>
+  | Token<TokenType.Top>;
+
+type QueryOption =
+  | SystemQueryOption
+  | Token<TokenType.AliasAndValue>
+  | Token<TokenType.CustomQueryOption>;
+
+type FunctionImportValue<T extends TokenType> = {
+  import: TokenOfType<T>;
+  params: Token<TokenType.FunctionParameter>[];
+};
+
+export interface QueryOptionsToken {
   type: TokenType.QueryOptions;
   value: {
-    options: Token[];
+    options: QueryOption[];
   };
 }
 
-export interface CustomQueryOptionToken extends Token {
+export interface CustomQueryOptionToken {
   type: TokenType.CustomQueryOption;
   value: {
     key: string;
-    value: any;
+    value: string;
   };
 }
 
-export interface LiteralToken extends Token {
+export interface LiteralToken {
   type: TokenType.Literal;
   /**
    * edm type
    */
-  value: PrimitiveTypeEnum;
+  value:
+    | PrimitiveTypeEnum
+    | Token<TokenType.Literal>
+    | 'SRID'
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'null'
+    | {
+        srid: Token<TokenType.Literal>;
+        value: Token<TokenType.Literal>;
+      }
+    | {
+        longitude: Token<TokenType.Literal>;
+        latitude: Token<TokenType.Literal>;
+      }
+    | {
+        items: Token<TokenType.Literal>[];
+      };
 }
 
-export interface SkipToken extends Token {
+export interface SkipToken {
   type: TokenType.Skip;
-  value: LiteralToken;
+  value: Token<TokenType.Literal>;
 }
 
-export interface TopToken extends Token {
+export interface TopToken {
   type: TokenType.Top;
-  value: LiteralToken;
+  value: Token<TokenType.Literal>;
 }
 
-export interface FormatToken extends Token {
+export interface FormatToken {
   type: TokenType.Format;
-  value: { format: string };
+  value: {
+    format: string;
+  };
 }
 
-export interface FilterToken extends Token {
+export interface FilterToken {
   type: TokenType.Filter;
-  value: EqualsExpressionToken | OrExpressionToken | AndExpressionToken;
+  value:
+    | Token<TokenType.IsOfExpression>
+    | Token<TokenType.MethodCallExpression>
+    | Token<TokenType.NotExpression>
+    | Token<TokenType.CommonExpression>
+    | Token<TokenType.BoolParenExpression>
+    | Token<TokenType.EqualsExpression>
+    | Token<TokenType.NotEqualsExpression>
+    | Token<TokenType.LesserThanExpression>
+    | Token<TokenType.LesserOrEqualsExpression>
+    | Token<TokenType.GreaterThanExpression>
+    | Token<TokenType.GreaterOrEqualsExpression>
+    | Token<TokenType.HasExpression>
+    | Token<TokenType.OrExpression>
+    | Token<TokenType.AndExpression>;
 }
 
-export interface ExpandToken extends Token {
+export interface ExpandToken {
   type: TokenType.Expand;
   value: {
     items: Token[];
   };
 }
 
-export interface SearchToken extends Token {
+export interface SearchToken {
   type: TokenType.Search;
-  value: SearchWordToken;
+  value:
+    | Token<TokenType.SearchPhrase>
+    | Token<TokenType.SearchTerm>
+    | Token<TokenType.SearchWord>
+    | Token<TokenType.SearchNotExpression>
+    | Token<TokenType.SearchParenExpression>
+    | Token<TokenType.SearchAndExpression>
+    | Token<TokenType.SearchOrExpression>;
 }
 
-export interface SearchWordToken extends Token {
+export interface SearchWordToken {
   type: TokenType.SearchWord;
   value: string;
 }
 
-export interface LeftRightExpressionToken extends Token {
+export interface LeftRightExpressionToken {
   value: {
     left: Token;
     right: Token;
   };
 }
 
-export interface MemberExpressionToken extends Token {
+export interface MemberExpressionToken {
   type: TokenType.MemberExpression;
-  value: Token;
+  value:
+    | Token<TokenType.PropertyPathExpression>
+    | Token<TokenType.FunctionExpression>
+    | {
+        name: Token<TokenType.QualifiedEntityTypeName>;
+        value:
+          | Token<TokenType.PropertyPathExpression>
+          | Token<TokenType.FunctionExpression>;
+      };
 }
 
-export interface FirstMemberExpressionToken extends Token {
+export interface FirstMemberExpressionToken {
   type: TokenType.FirstMemberExpression;
+  value:
+    | Token<TokenType.LambdaVariableExpression>
+    | Token<TokenType.ImplicitVariableExpression>
+    | Token<TokenType.ODataIdentifier>
+    | Token<TokenType.MemberExpression>
+    | [
+        Token<TokenType.LambdaVariableExpression> | Token<TokenType.ImplicitVariableExpression> | Token<TokenType.ODataIdentifier>,
+        Token<TokenType.MemberExpression>
+      ];
+}
+
+export interface AndExpressionToken {
+  type: TokenType.AndExpression;
+  value: LeftRightExpressionValue<
+    Token,
+    | Token<TokenType.CommonExpression>
+    | Token<TokenType.NotExpression>
+    | Token<TokenType.BoolParenExpression>
+    | Token<TokenType.MethodCallExpression>
+    | Token<TokenType.IsOfExpression>
+    | Token<TokenType.EqualsExpression>
+    | Token<TokenType.NotEqualsExpression>
+    | Token<TokenType.LesserThanExpression>
+    | Token<TokenType.LesserOrEqualsExpression>
+    | Token<TokenType.GreaterThanExpression>
+    | Token<TokenType.GreaterOrEqualsExpression>
+    | Token<TokenType.HasExpression>
+    | Token<TokenType.AndExpression>
+    | Token<TokenType.OrExpression>
+  >;
+}
+
+export interface OrExpressionToken {
+  type: TokenType.OrExpression;
+  value: LeftRightExpressionValue<
+    Token,
+    | Token<TokenType.CommonExpression>
+    | Token<TokenType.NotExpression>
+    | Token<TokenType.BoolParenExpression>
+    | Token<TokenType.MethodCallExpression>
+    | Token<TokenType.IsOfExpression>
+    | Token<TokenType.EqualsExpression>
+    | Token<TokenType.NotEqualsExpression>
+    | Token<TokenType.LesserThanExpression>
+    | Token<TokenType.LesserOrEqualsExpression>
+    | Token<TokenType.GreaterThanExpression>
+    | Token<TokenType.GreaterOrEqualsExpression>
+    | Token<TokenType.HasExpression>
+    | Token<TokenType.AndExpression>
+    | Token<TokenType.OrExpression>
+  >;
+}
+
+export interface EqualsExpressionToken {
+  type: TokenType.EqualsExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface ArrayOrObjectToken {
+  type: TokenType.ArrayOrObject;
+  value: Token<TokenType.Object> | Token<TokenType.Array>;
+}
+
+export interface ArrayToken {
+  type: TokenType.Array;
+  value: {
+    items: Token<TokenType.Object>[];
+  };
+}
+
+export interface ObjectToken {
+  type: TokenType.Object;
+  value: {
+    items: (Token<TokenType.Annotation> | Token<TokenType.Property>)[];
+  };
+}
+
+export interface PropertyToken {
+  type: TokenType.Property;
+  value: {
+    key:
+      | Token<TokenType.PrimitiveKeyProperty>
+      | Token<TokenType.PrimitiveCollectionProperty>
+      | Token<TokenType.ComplexCollectionProperty>
+      | Token<TokenType.ComplexProperty>;
+    value: Token<TokenType.Array> | Token<TokenType.Object>;
+  };
+}
+
+export interface AnnotationToken {
+  type: TokenType.Annotation;
+  value: {
+    key: string;
+    value: Token<TokenType.Literal> | Token<TokenType.Object> | Token<TokenType.Array>;
+  };
+}
+
+export interface EnumToken {
+  type: TokenType.Enum;
+  value: {
+    name: Token<TokenType.Identifier>;
+    value: Token<TokenType.EnumValue>;
+  };
+}
+
+export interface EnumValueToken {
+  type: TokenType.EnumValue;
+  value: {
+    values: Token<TokenType.EnumerationMember | TokenType.EnumMemberValue>[];
+  };
+}
+
+export interface EnumMemberValueToken {
+  type: TokenType.EnumMemberValue;
+  value: string;
+}
+
+export interface IdentifierToken {
+  type: TokenType.Identifier;
+  value: string;
+}
+
+export interface QualifiedEntityTypeNameToken {
+  type: TokenType.QualifiedEntityTypeName;
+  value: Token<TokenType.EntityTypeName>;
+}
+
+export interface QualifiedComplexTypeNameToken {
+  type: TokenType.QualifiedComplexTypeName;
+  value: Token<TokenType.ComplexTypeName>;
+}
+
+export interface ODataIdentifierToken {
+  type: TokenType.ODataIdentifier;
+  value: NamespacedNamedValue;
+}
+
+export interface CollectionToken {
+  type: TokenType.Collection;
+  value: Token[];
+}
+
+export interface NamespacePartToken {
+  type: TokenType.NamespacePart;
+  value: NamedValue | Token[];
+}
+
+export interface EntitySetNameToken {
+  type: TokenType.EntitySetName;
+  value: NamedValue;
+}
+
+export interface SingletonEntityToken {
+  type: TokenType.SingletonEntity;
+  value: NamedValue;
+}
+
+export interface EntityTypeNameToken {
+  type: TokenType.EntityTypeName;
+  value: NamespacedNamedValue;
+}
+
+export interface ComplexTypeNameToken {
+  type: TokenType.ComplexTypeName;
+  value: NamespacedNamedValue;
+}
+
+export interface TypeDefinitionNameToken {
+  type: TokenType.TypeDefinitionName;
+  value: NamedValue;
+}
+
+export interface EnumerationTypeNameToken {
+  type: TokenType.EnumerationTypeName;
+  value: NamedValue;
+}
+
+export interface EnumerationMemberToken {
+  type: TokenType.EnumerationMember;
+  value: NamedValue;
+}
+
+export interface TermNameToken {
+  type: TokenType.TermName;
+  value: NamedValue;
+}
+
+export interface PrimitivePropertyToken {
+  type: TokenType.PrimitiveProperty;
+  value: NamedValue;
+}
+
+export interface PrimitiveKeyPropertyToken {
+  type: TokenType.PrimitiveKeyProperty;
+  value: NamedValue;
+}
+
+export interface PrimitiveNonKeyPropertyToken {
+  type: TokenType.PrimitiveNonKeyProperty;
+  value: string;
+}
+
+export interface PrimitiveCollectionPropertyToken {
+  type: TokenType.PrimitiveCollectionProperty;
+  value: NamedValue;
+}
+
+export interface ComplexPropertyToken {
+  type: TokenType.ComplexProperty;
+  value: NamedValue;
+}
+
+export interface ComplexCollectionPropertyToken {
+  type: TokenType.ComplexCollectionProperty;
+  value: NamedValue;
+}
+
+export interface StreamPropertyToken {
+  type: TokenType.StreamProperty;
+  value: NamedValue;
+}
+
+export interface NavigationPropertyToken {
+  type: TokenType.NavigationProperty;
+  value: string;
+}
+
+export interface EntityNavigationPropertyToken {
+  type: TokenType.EntityNavigationProperty;
+  value: NamedValue;
+}
+
+export interface EntityCollectionNavigationPropertyToken {
+  type: TokenType.EntityCollectionNavigationProperty;
+  value: NamedValue;
+}
+
+export interface ActionToken {
+  type: TokenType.Action;
+  value: NamespacedNamedValue | Token<TokenType.Action>;
+}
+
+export interface ActionImportToken {
+  type: TokenType.ActionImport;
+  value: NamedValue;
+}
+
+export interface FunctionToken {
+  type: TokenType.Function;
+  value: {
+    name: Token<
+      | TokenType.EntityFunction
+      | TokenType.EntityCollectionFunction
+      | TokenType.ComplexFunction
+      | TokenType.ComplexCollectionFunction
+      | TokenType.PrimitiveFunction
+      | TokenType.PrimitiveCollectionFunction
+    >;
+    parameters: Token<TokenType.ParameterName>[];
+  };
+}
+
+export interface EntityFunctionToken {
+  type: TokenType.EntityFunction;
+  value: NamespacedNamedValue;
+}
+
+export interface EntityCollectionFunctionToken {
+  type: TokenType.EntityCollectionFunction;
+  value: NamespacedNamedValue;
+}
+
+export interface ComplexFunctionToken {
+  type: TokenType.ComplexFunction;
+  value: NamespacedNamedValue;
+}
+
+export interface ComplexCollectionFunctionToken {
+  type: TokenType.ComplexCollectionFunction;
+  value: NamespacedNamedValue;
+}
+
+export interface PrimitiveFunctionToken {
+  type: TokenType.PrimitiveFunction;
+  value: NamespacedNamedValue;
+}
+
+export interface PrimitiveCollectionFunctionToken {
+  type: TokenType.PrimitiveCollectionFunction;
+  value: NamespacedNamedValue;
+}
+
+export interface EntityFunctionImportToken {
+  type: TokenType.EntityFunctionImport;
+  value: NamedValue;
+}
+
+export interface EntityCollectionFunctionImportToken {
+  type: TokenType.EntityCollectionFunctionImport;
+  value: NamedValue;
+}
+
+export interface ComplexFunctionImportToken {
+  type: TokenType.ComplexFunctionImport;
+  value: NamedValue;
+}
+
+export interface ComplexCollectionFunctionImportToken {
+  type: TokenType.ComplexCollectionFunctionImport;
+  value: NamedValue;
+}
+
+export interface PrimitiveFunctionImportToken {
+  type: TokenType.PrimitiveFunctionImport;
+  value: NamedValue;
+}
+
+export interface PrimitiveCollectionFunctionImportToken {
+  type: TokenType.PrimitiveCollectionFunctionImport;
+  value: NamedValue;
+}
+
+export interface CommonExpressionToken {
+  type: TokenType.CommonExpression;
+  value:
+    | Token<TokenType.Identifier>
+    | Token<TokenType.Literal>
+    | Token<TokenType.Enum>
+    | Token<TokenType.ParameterAlias>
+    | Token<TokenType.ArrayOrObject>
+    | Token<TokenType.RootExpression>
+    | Token<TokenType.FirstMemberExpression>
+    | Token<TokenType.FunctionExpression>
+    | Token<TokenType.NegateExpression>
+    | Token<TokenType.MethodCallExpression>
+    | Token<TokenType.ParenExpression>
+    | Token<TokenType.CastExpression>
+    | Token<TokenType.AddExpression>
+    | Token<TokenType.AddExpression>
+    | Token<TokenType.SubExpression>
+    | Token<TokenType.MulExpression>
+    | Token<TokenType.DivExpression>
+    | Token<TokenType.ModExpression>
+    | Token<TokenType.AndExpression>
+    | Token<TokenType.OrExpression>;
+}
+
+export interface NotEqualsExpressionToken {
+  type: TokenType.NotEqualsExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface LesserThanExpressionToken {
+  type: TokenType.LesserThanExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface LesserOrEqualsExpressionToken {
+  type: TokenType.LesserOrEqualsExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface GreaterThanExpressionToken {
+  type: TokenType.GreaterThanExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface GreaterOrEqualsExpressionToken {
+  type: TokenType.GreaterOrEqualsExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface HasExpressionToken {
+  type: TokenType.HasExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface AddExpressionToken {
+  type: TokenType.AddExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface SubExpressionToken {
+  type: TokenType.SubExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface MulExpressionToken {
+  type: TokenType.MulExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface DivExpressionToken {
+  type: TokenType.DivExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface ModExpressionToken {
+  type: TokenType.ModExpression;
+  value: LeftRightExpressionValue<Token, LeftRightExpressionTokenValue>;
+}
+
+export interface NotExpressionToken {
+  type: TokenType.NotExpression;
+  value:
+    | Token<TokenType.IsOfExpression>
+    | Token<TokenType.MethodCallExpression>
+    | Token<TokenType.NotExpression>
+    | Token<TokenType.CommonExpression>
+    | Token<TokenType.BoolParenExpression>
+    | Token<TokenType.EqualsExpression>
+    | Token<TokenType.NotEqualsExpression>
+    | Token<TokenType.LesserThanExpression>
+    | Token<TokenType.LesserOrEqualsExpression>
+    | Token<TokenType.GreaterThanExpression>
+    | Token<TokenType.GreaterOrEqualsExpression>
+    | Token<TokenType.HasExpression>
+    | Token<TokenType.AndExpression>
+    | Token<TokenType.OrExpression>;
+  // value: LeftRightExpressionValue<Token, Token<TokenType.CommonExpression>>;
+}
+
+export interface BoolParenExpressionToken {
+  type: TokenType.BoolParenExpression;
+  value:
+     | Token<TokenType.IsOfExpression>
+     | Token<TokenType.MethodCallExpression>
+     | Token<TokenType.NotExpression>
+     | Token<TokenType.CommonExpression>
+     | Token<TokenType.BoolParenExpression>
+     | Token<TokenType.EqualsExpression>
+     | Token<TokenType.NotEqualsExpression>
+     | Token<TokenType.LesserThanExpression>
+     | Token<TokenType.LesserOrEqualsExpression>
+     | Token<TokenType.GreaterThanExpression>
+     | Token<TokenType.GreaterOrEqualsExpression>
+     | Token<TokenType.HasExpression>
+     | Token<TokenType.AndExpression>
+     | Token<TokenType.OrExpression>;
+}
+
+export interface ParenExpressionToken {
+  type: TokenType.ParenExpression;
   value: Token;
 }
 
-export interface EqualsExpressionToken extends LeftRightExpressionToken {
-  type: TokenType.EqualsExpression;
+export interface MethodCallExpressionToken {
+  type: TokenType.MethodCallExpression;
+  value: {
+    method: string;
+    parameters: Token[];
+  };
 }
 
-export interface AndExpressionToken extends LeftRightExpressionToken {
-  type: TokenType.AndExpression;
+export interface IsOfExpressionToken {
+  type: TokenType.IsOfExpression;
+  value: {
+    target: Token<TokenType.CommonExpression>;
+    typename:
+      | Token<TokenType.Identifier>
+      | Token<TokenType.QualifiedEntityTypeName>
+      | Token<TokenType.QualifiedComplexTypeName>
+      | Token<TokenType.Collection>;
+  };
 }
 
-export interface OrExpressionToken extends LeftRightExpressionToken {
-  type: TokenType.OrExpression;
+export interface CastExpressionToken {
+  type: TokenType.CastExpression;
+  value: {
+    target: Token<TokenType.CommonExpression>;
+    typename:
+      | Token<TokenType.Identifier>
+      | Token<TokenType.QualifiedEntityTypeName>
+      | Token<TokenType.QualifiedComplexTypeName>
+      | Token<TokenType.Collection>;
+  };
 }
+
+export interface NegateExpressionToken {
+  type: TokenType.NegateExpression;
+  value: Token<TokenType.CommonExpression>;
+}
+
+export interface PropertyPathExpressionToken {
+  type: TokenType.PropertyPathExpression;
+  value:
+    | TokenOfType<TokenType.ODataIdentifier | TokenType.StreamProperty>
+    | {
+        current: Token<TokenType.ODataIdentifier>;
+        next: TokenOfType<
+          | TokenType.SingleNavigationExpression
+          | TokenType.CollectionPathExpression
+          | TokenType.CollectionNavigationExpression
+          | TokenType.ComplexPathExpression
+          | TokenType.SinglePathExpression
+        >;
+      };
+}
+
+export interface ImplicitVariableExpressionToken {
+  type: TokenType.ImplicitVariableExpression;
+  value: string;
+}
+
+export interface LambdaVariableToken {
+  type: TokenType.LambdaVariable;
+  value: string;
+}
+
+export interface LambdaVariableExpressionToken {
+  type: TokenType.LambdaVariableExpression;
+  value: { name: string };
+}
+
+export interface LambdaPredicateExpressionToken {
+  type: TokenType.LambdaPredicateExpression;
+  value:
+    | Token<TokenType.CommonExpression>
+    | Token<TokenType.AndExpression>
+    | Token<TokenType.OrExpression>
+    | Token<TokenType.NotExpression>
+    | Token<TokenType.BoolParenExpression>
+    | Token<TokenType.MethodCallExpression>
+    | Token<TokenType.IsOfExpression>
+    | Token<TokenType.EqualsExpression>
+    | Token<TokenType.NotEqualsExpression>
+    | Token<TokenType.LesserThanExpression>
+    | Token<TokenType.LesserOrEqualsExpression>
+    | Token<TokenType.GreaterThanExpression>
+    | Token<TokenType.GreaterOrEqualsExpression>
+    | Token<TokenType.HasExpression>;
+}
+
+export interface AnyExpressionToken {
+  type: TokenType.AnyExpression;
+  value: {
+    variable: Token<TokenType.LambdaVariableExpression>;
+    predicate: Token<TokenType.LambdaPredicateExpression>;
+  };
+}
+
+export interface AllExpressionToken {
+  type: TokenType.AllExpression;
+  value: {
+    variable: Token<TokenType.LambdaVariableExpression>;
+    predicate: Token<TokenType.LambdaPredicateExpression>;
+  };
+}
+
+export interface CollectionNavigationExpressionToken {
+  type: TokenType.CollectionNavigationExpression;
+  value: {
+    entity: Token<TokenType.QualifiedEntityTypeName>;
+    predicate: Token<TokenType.SimpleKey> | Token<TokenType.CompoundKey>;
+    navigation: Token<TokenType.SingleNavigationExpression>;
+    path: Token<TokenType.CollectionPathExpression>;
+  };
+}
+
+export interface SimpleKeyToken {
+  type: TokenType.SimpleKey;
+  value: {
+    key: string;
+    value: Token<TokenType.KeyPropertyValue>;
+  };
+}
+
+export interface CompoundKeyToken {
+  type: TokenType.CompoundKey;
+  value: Token<TokenType.KeyValuePair>[];
+}
+
+export interface KeyValuePairToken {
+  type: TokenType.KeyValuePair;
+  value: {
+    key: Token<TokenType.PrimitiveKeyProperty> | Token<TokenType.KeyPropertyAlias>;
+    value: Token<TokenType.KeyPropertyValue>;
+  };
+}
+
+export interface KeyPropertyValueToken {
+  type: TokenType.KeyPropertyValue;
+  value: string;
+}
+
+export interface KeyPropertyAliasToken {
+  type: TokenType.KeyPropertyAlias;
+  value: { name: string };
+}
+
+export interface SingleNavigationExpressionToken {
+  type: TokenType.SingleNavigationExpression;
+  value: Token<TokenType.MemberExpression>;
+}
+
+export interface CollectionPathExpressionToken {
+  type: TokenType.CollectionPathExpression;
+  value:
+    | Token<TokenType.AnyExpression>
+    | Token<TokenType.AllExpression>
+    | Token<TokenType.FunctionExpression>
+    | Token<TokenType.CountExpression>;
+}
+
+export interface ComplexPathExpressionToken {
+  type: TokenType.ComplexPathExpression;
+  value:
+    | [Token<TokenType.FunctionExpression> | Token<TokenType.PropertyPathExpression>]
+    | [
+        Token<TokenType.QualifiedComplexTypeName>,
+        Token<TokenType.FunctionExpression> | Token<TokenType.PropertyPathExpression>
+      ];
+}
+
+export interface SinglePathExpressionToken {
+  type: TokenType.SinglePathExpression;
+  value: Token<TokenType.FunctionExpression>;
+}
+
+export interface FunctionExpressionToken {
+  type: TokenType.FunctionExpression;
+  value: {
+    fn: Token<TokenType.ODataIdentifier>;
+    params: Token<TokenType.FunctionExpressionParameters>;
+    expression:
+      | Token<TokenType.CollectionNavigationExpression>
+      | Token<TokenType.CollectionPathExpression>
+      | Token<TokenType.ComplexPathExpression>
+      | Token<TokenType.SingleNavigationExpression>
+      | Token<TokenType.SinglePathExpression>;
+  };
+}
+
+export interface FunctionExpressionParametersToken {
+  type: TokenType.FunctionExpressionParameters;
+  value: Token<TokenType.FunctionExpressionParameter>[];
+}
+
+export interface FunctionExpressionParameterToken {
+  type: TokenType.FunctionExpressionParameter;
+  value: {
+    name: Token<TokenType.ParameterName>;
+    value: Token<TokenType.ParameterAlias> | Token<TokenType.ParameterValue>;
+  };
+}
+
+export interface ParameterNameToken {
+  type: TokenType.ParameterName;
+  value: string;
+}
+
+export interface ParameterAliasToken {
+  type: TokenType.ParameterAlias;
+  value: { name: string };
+}
+
+export interface ParameterValueToken {
+  type: TokenType.ParameterValue;
+  value:
+    | Token<TokenType.ArrayOrObject>
+    | Token<TokenType.Array>
+    | Token<TokenType.Object>
+    | Token<TokenType.Identifier>
+    | Token<TokenType.FunctionExpression>
+    | Token<TokenType.ParameterAlias>
+    | Token<TokenType.Literal>
+    | Token<TokenType.OrExpression>
+    | Token<TokenType.AndExpression>
+    | Token<TokenType.MethodCallExpression>
+    | Token<TokenType.Enum>
+    | Token<TokenType.RootExpression>
+    | Token<TokenType.FirstMemberExpression>
+    | Token<TokenType.NegateExpression>
+    | Token<TokenType.ParenExpression>
+    | Token<TokenType.CastExpression>
+    | Token<TokenType.AddExpression>
+    | Token<TokenType.SubExpression>
+    | Token<TokenType.MulExpression>
+    | Token<TokenType.DivExpression>
+    | Token<TokenType.ModExpression>;
+}
+
+export interface CountExpressionToken {
+  type: TokenType.CountExpression;
+  value: string;
+}
+
+export interface RefExpressionToken {
+  type: TokenType.RefExpression;
+  value: string;
+}
+
+export interface ValueExpressionToken {
+  type: TokenType.ValueExpression;
+  value: string;
+}
+
+export interface RootExpressionToken {
+  type: TokenType.RootExpression;
+  value: {
+    current:
+      | { entity: Token<TokenType.SingletonEntity> }
+      | {
+          entitySet: Token<TokenType.EntitySetName>;
+          keys: Token<TokenType.SimpleKey> | Token<TokenType.CompoundKey>;
+        };
+    next: SingleNavigationExpressionToken;
+  };
+}
+
+export interface ExpandToken {
+  type: TokenType.Expand;
+  value: {
+    items: Token[];
+  };
+}
+
+export interface ExpandItemToken {
+  type: TokenType.ExpandItem;
+  value: {
+    path:
+      | Token<TokenType.ExpandPath>
+      | '*';
+    levels?: Token<TokenType.Levels>;
+    ref?: Token<TokenType.RefExpression>;
+    count?: Token<TokenType.CountExpression>;
+    options?: TokenOfType<
+      | TokenType.Filter
+      | TokenType.Search
+      | TokenType.OrderBy
+      | TokenType.Skip
+      | TokenType.Top
+      | TokenType.InlineCount
+    >[];
+  };
+}
+
+export interface ExpandPathToken {
+  type: TokenType.ExpandPath;
+  value: (
+    | Token<TokenType.QualifiedEntityTypeName>
+    | Token<TokenType.QualifiedComplexTypeName>
+    | Token<TokenType.ComplexProperty>
+    | Token<TokenType.ComplexCollectionProperty>
+    | Token<TokenType.EntityNavigationProperty>
+    | Token<TokenType.EntityCollectionNavigationProperty>
+  )[];
+}
+
+export interface ExpandCountOptionToken {
+  type: TokenType.ExpandCountOption;
+  value: string;
+}
+
+export interface ExpandRefOptionToken {
+  type: TokenType.ExpandRefOption;
+  value: string;
+}
+
+export interface ExpandOptionToken {
+  type: TokenType.ExpandOption;
+  value: string;
+}
+
+export interface LevelsToken {
+  type: TokenType.Levels;
+  value: string;
+}
+
+export interface SearchExpressionToken {
+  type: TokenType.SearchExpression;
+  value: string;
+}
+
+export interface SearchParenExpressionToken {
+  type: TokenType.SearchParenExpression;
+  value:
+    | Token<TokenType.SearchAndExpression>
+    | Token<TokenType.SearchOrExpression>
+    | Token<TokenType.SearchNotExpression>
+    | Token<TokenType.SearchPhrase>
+    | Token<TokenType.SearchTerm>
+    | Token<TokenType.SearchWord>
+    | Token<TokenType.SearchParenExpression>;
+}
+
+export interface SearchNotExpressionToken {
+  type: TokenType.SearchNotExpression;
+  value: Token<TokenType.SearchPhrase> | Token<TokenType.SearchWord>;
+}
+
+export interface SearchOrExpressionToken {
+  type: TokenType.SearchOrExpression;
+  value: {
+    left:
+      | Token<TokenType.SearchParenExpression>
+      | Token<TokenType.SearchAndExpression>
+      | Token<TokenType.SearchOrExpression>
+      | Token<TokenType.SearchNotExpression>
+      | Token<TokenType.SearchPhrase>
+      | Token<TokenType.SearchWord>;
+    right:
+      | Token<TokenType.SearchAndExpression>
+      | Token<TokenType.SearchOrExpression>
+      | Token<TokenType.SearchNotExpression>
+      | Token<TokenType.SearchPhrase>
+      | Token<TokenType.SearchTerm>
+      | Token<TokenType.SearchWord>
+      | Token<TokenType.SearchParenExpression>;
+  };
+}
+
+export interface SearchAndExpressionToken {
+  type: TokenType.SearchAndExpression;
+  value: {
+    left:
+      | Token<TokenType.SearchParenExpression>
+      | Token<TokenType.SearchAndExpression>
+      | Token<TokenType.SearchOrExpression>
+      | Token<TokenType.SearchNotExpression>
+      | Token<TokenType.SearchPhrase>
+      | Token<TokenType.SearchWord>;
+    right:
+      | Token<TokenType.SearchAndExpression>
+      | Token<TokenType.SearchOrExpression>
+      | Token<TokenType.SearchNotExpression>
+      | Token<TokenType.SearchPhrase>
+      | Token<TokenType.SearchTerm>
+      | Token<TokenType.SearchWord>
+      | Token<TokenType.SearchParenExpression>;
+  };
+}
+
+export interface SearchTermToken {
+  type: TokenType.SearchTerm;
+  value: string;
+}
+
+export interface SearchPhraseToken {
+  type: TokenType.SearchPhrase;
+  value: string;
+}
+
+export interface SearchWordToken {
+  type: TokenType.SearchWord;
+  value: string;
+}
+
+export interface OrderByToken {
+  type: TokenType.OrderBy;
+  value: {
+    items: Token<TokenType.OrderByItem>[];
+  };
+}
+
+export interface OrderByItemToken {
+  type: TokenType.OrderByItem;
+  value: {
+    expr: Token<TokenType.CommonExpression>;
+    direction: number;
+  };
+}
+
+export interface FormatToken {
+  type: TokenType.Format;
+  value: { format: string };
+}
+
+export interface InlineCountToken {
+  type: TokenType.InlineCount;
+  value: Token<TokenType.Literal>;
+}
+
+export interface SelectToken {
+  type: TokenType.Select;
+  value: {
+    items: Token<TokenType.SelectItem>[];
+  };
+}
+
+export interface SelectItemToken {
+  type: TokenType.SelectItem;
+  value:
+    | Token<TokenType.PrimitiveProperty>
+    | Token<TokenType.PrimitiveKeyProperty>
+    | Token<TokenType.PrimitiveCollectionProperty>
+    | Token<TokenType.EntityNavigationProperty>
+    | Token<TokenType.EntityCollectionNavigationProperty>
+    | Token<TokenType.Action>
+    | Token<TokenType.Function>
+    | Token<TokenType.SelectPath>
+    | { value: string }
+    | { namespace: string; value: string }
+    | {
+        name: Token<TokenType.QualifiedEntityTypeName | TokenType.QualifiedComplexTypeName>;
+        value:
+          | Token<TokenType.PrimitiveProperty>
+          | Token<TokenType.PrimitiveKeyProperty>
+          | Token<TokenType.PrimitiveCollectionProperty>
+          | Token<TokenType.EntityNavigationProperty>
+          | Token<TokenType.EntityCollectionNavigationProperty>
+          | Token<TokenType.Action>
+          | Token<TokenType.Function>
+          | Token<TokenType.SelectPath>;
+      };
+}
+
+export interface SelectPathToken {
+  type: TokenType.SelectPath;
+  value:
+    | Token<TokenType.ComplexProperty>
+    | Token<TokenType.ComplexCollectionProperty>
+    | {
+        prop: Token<TokenType.ComplexProperty> | Token<TokenType.ComplexCollectionProperty>;
+        name: Token<TokenType.QualifiedComplexTypeName>;
+      }
+    | {
+        path: Token<TokenType.SelectPath>;
+        next:
+          | Token<TokenType.EntityCollectionNavigationProperty>
+          | Token<TokenType.EntityNavigationProperty>
+          | Token<TokenType.PrimitiveCollectionProperty>
+          | Token<TokenType.PrimitiveKeyProperty>
+          | Token<TokenType.PrimitiveProperty>
+          | Token<TokenType.SelectPath>;
+      };
+}
+
+export interface AliasAndValueToken {
+  type: TokenType.AliasAndValue;
+  value: {
+    alias: Token<TokenType.ParameterAlias>;
+    value: Token<TokenType.ParameterValue>;
+  };
+}
+
+export interface SkipTokenToken {
+  type: TokenType.SkipToken;
+  value: string;
+}
+
+export interface IdToken {
+  type: TokenType.Id;
+  value: string;
+}
+
+export interface CrossjoinToken {
+  type: TokenType.Crossjoin;
+  value: {
+    names: Token<TokenType.EntitySetName>[];
+  };
+}
+
+export interface AllResourceToken {
+  type: TokenType.AllResource;
+  value: string;
+}
+
+export interface ActionImportCallToken {
+  type: TokenType.ActionImportCall;
+  value: Token<TokenType.ActionImport>;
+}
+
+export interface EntityCollectionFunctionImportCallToken {
+  type: TokenType.EntityCollectionFunctionImportCall;
+  value: FunctionImportValue<TokenType.EntityCollectionFunctionImport>;
+}
+
+export interface EntityFunctionImportCallToken {
+  type: TokenType.EntityFunctionImportCall;
+  value: FunctionImportValue<TokenType.EntityFunctionImport>;
+}
+
+export interface ComplexCollectionFunctionImportCallToken {
+  type: TokenType.ComplexCollectionFunctionImportCall;
+  value: FunctionImportValue<TokenType.ComplexCollectionFunctionImport>;
+}
+
+export interface ComplexFunctionImportCallToken {
+  type: TokenType.ComplexFunctionImportCall;
+  value: FunctionImportValue<TokenType.ComplexFunctionImport>;
+}
+
+export interface PrimitiveCollectionFunctionImportCallToken {
+  type: TokenType.PrimitiveCollectionFunctionImportCall;
+  value: FunctionImportValue<TokenType.PrimitiveCollectionFunctionImport>;
+}
+
+export interface PrimitiveFunctionImportCallToken {
+  type: TokenType.PrimitiveFunctionImportCall;
+  value: FunctionImportValue<TokenType.PrimitiveFunctionImport>;
+}
+
+export interface FunctionParametersToken {
+  type: TokenType.FunctionParameters;
+  value: Token<TokenType.FunctionParameter>[];
+}
+
+export interface FunctionParameterToken {
+  type: TokenType.FunctionParameter;
+  value: {
+    name: Token<TokenType.ParameterName>;
+    value: Token<TokenType.Literal> | Token<TokenType.Enum> | Token<TokenType.ParameterAlias>;
+  };
+}
+
+export interface ResourcePathToken {
+  type: TokenType.ResourcePath;
+  value: {
+    resource:
+      | Token<TokenType.EntitySetName>
+      | Token<TokenType.EntityCollectionFunctionImportCall>
+      | Token<TokenType.SingletonEntity>
+      | Token<TokenType.EntityFunctionImportCall>
+      | Token<TokenType.ComplexCollectionFunctionImportCall>
+      | Token<TokenType.PrimitiveCollectionFunctionImportCall>
+      | Token<TokenType.ComplexFunctionImportCall>
+      | Token<TokenType.PrimitiveFunctionImportCall>
+      | Token<TokenType.Crossjoin>
+      | Token<TokenType.AllResource>
+      | Token<TokenType.ActionImportCall>;
+    navigation:
+      | Token<TokenType.CollectionNavigation>
+      | Token<TokenType.SingleNavigation>
+      | Token<TokenType.CountExpression>
+      | Token<TokenType.BoundOperation>
+      | Token<TokenType.ComplexPath>
+      | Token<TokenType.ValueExpression>
+      | Token<TokenType.RefExpression>;
+  };
+}
+
+export interface CollectionNavigationToken {
+  type: TokenType.CollectionNavigation;
+  value: {
+    name: Token<TokenType.QualifiedEntityTypeName>;
+    path:
+      | Token<TokenType.RefExpression>
+      | Token<TokenType.CountExpression>
+      | Token<TokenType.BoundOperation>
+      | Token<TokenType.CollectionNavigationPath>;
+  };
+}
+
+export interface CollectionNavigationPathToken {
+  type: TokenType.CollectionNavigationPath;
+  value: {
+    predicate: Token<TokenType.SimpleKey> | Token<TokenType.CompoundKey>;
+    navigation?:
+      | Token<TokenType.SingleNavigation>
+      | Token<TokenType.BoundOperation>
+      | Token<TokenType.ValueExpression>
+      | Token<TokenType.RefExpression>;
+  };
+}
+
+export interface SingleNavigationToken {
+  type: TokenType.SingleNavigation;
+  value: {
+    name: Token<TokenType.QualifiedEntityTypeName>;
+    path:
+      | Token<TokenType.RefExpression>
+      | Token<TokenType.ValueExpression>
+      | Token<TokenType.BoundOperation>
+      | Token<TokenType.PropertyPath>;
+  };
+}
+
+export interface PropertyPathToken {
+  type: TokenType.PropertyPath;
+  value: {
+    path:
+      | Token<TokenType.PrimitiveProperty>
+      | Token<TokenType.PrimitiveKeyProperty>
+      | Token<TokenType.PrimitiveCollectionProperty>
+      | Token<TokenType.EntityNavigationProperty>
+      | Token<TokenType.EntityCollectionNavigationProperty>
+      | Token<TokenType.ComplexProperty>
+      | Token<TokenType.ComplexCollectionProperty>
+      | Token<TokenType.StreamProperty>;
+    navigation:
+      | Token<TokenType.RefExpression>
+      | Token<TokenType.CollectionNavigation>
+      | Token<TokenType.SingleNavigation>
+      | Token<TokenType.CountExpression>
+      | Token<TokenType.BoundOperation>
+      | Token<TokenType.ComplexPath>
+      | Token<TokenType.ValueExpression>;
+  };
+}
+
+export interface ComplexPathToken {
+  type: TokenType.ComplexPath;
+  value: {
+    name: Token<TokenType.QualifiedComplexTypeName>;
+    path: Token<TokenType.BoundOperation> | Token<TokenType.PropertyPath>;
+  };
+}
+
+export interface BoundOperationToken {
+  type: TokenType.BoundOperation;
+  value: {
+    operation:
+      | Token<TokenType.BoundActionCall>
+      | Token<TokenType.BoundEntityFunctionCall>
+      | Token<TokenType.BoundEntityCollectionFunctionCall>
+      | Token<TokenType.BoundComplexFunctionCall>
+      | Token<TokenType.BoundComplexCollectionFunctionCall>
+      | Token<TokenType.BoundPrimitiveFunctionCall>
+      | Token<TokenType.BoundPrimitiveCollectionFunctionCall>;
+    name: Token<TokenType.QualifiedComplexTypeName>;
+    navigation:
+      | Token<TokenType.RefExpression>
+      | Token<TokenType.CollectionNavigation>
+      | Token<TokenType.SingleNavigation>
+      | Token<TokenType.CountExpression>
+      | Token<TokenType.BoundOperation>
+      | Token<TokenType.ComplexPath>
+      | Token<TokenType.ValueExpression>;
+  };
+}
+
+export interface BoundActionCallToken {
+  type: TokenType.BoundActionCall;
+  value: Token<TokenType.Action>;
+}
+
+export interface BoundEntityFunctionCallToken {
+  type: TokenType.BoundEntityFunctionCall;
+  value: {
+    call: Token<TokenType.EntityFunction>;
+    params: Token<TokenType.FunctionParameters>;
+  };
+}
+
+export interface BoundEntityCollectionFunctionCallToken {
+  type: TokenType.BoundEntityCollectionFunctionCall;
+  value: {
+    call: Token<TokenType.EntityCollectionFunction>;
+    params: Token<TokenType.FunctionParameters>;
+  };
+}
+
+export interface BoundComplexFunctionCallToken {
+  type: TokenType.BoundComplexFunctionCall;
+  value: {
+    call: Token<TokenType.ComplexFunction>;
+    params: Token<TokenType.FunctionParameters>;
+  };
+}
+
+export interface BoundComplexCollectionFunctionCallToken {
+  type: TokenType.BoundComplexCollectionFunctionCall;
+  value: {
+    call: Token<TokenType.ComplexCollectionFunction>;
+    params: Token<TokenType.FunctionParameters>;
+  };
+}
+
+export interface BoundPrimitiveFunctionCallToken {
+  type: TokenType.BoundPrimitiveFunctionCall;
+  value: {
+    call: Token<TokenType.PrimitiveFunction>;
+    params: Token<TokenType.FunctionParameters>;
+  };
+}
+
+export interface BoundPrimitiveCollectionFunctionCallToken {
+  type: TokenType.BoundPrimitiveCollectionFunctionCall;
+  value: {
+    call: Token<TokenType.PrimitiveCollectionFunction>;
+    params: Token<TokenType.FunctionParameters>;
+  };
+}
+
+export interface ODataUriToken {
+  type: TokenType.ODataUri;
+  value: {
+    resource:
+      | Token<TokenType.ResourcePath>
+      | Token<TokenType.Batch>
+      | Token<TokenType.Entity>
+      | Token<TokenType.Metadata>;
+    query: Token<TokenType.QueryOptions>;
+  };
+}
+
+export interface BatchToken {
+  type: TokenType.Batch;
+  value: string;
+}
+
+export interface EntityToken {
+  type: TokenType.Entity;
+  value: string | Token<TokenType.QualifiedEntityTypeName>;
+}
+
+export interface MetadataToken {
+  type: TokenType.Metadata;
+  value: string;
+}
+
+export type TokenTypeValue<T extends TokenType> = AllTokens[T]['value'];
+
+export type TokenOfType<T extends TokenType> = {
+  [K in keyof AllTokens & T]: Token<K>;
+}[T];
+
+type AllTokens = {
+  [TokenType.Literal]: LiteralToken,
+  [TokenType.ArrayOrObject]: ArrayOrObjectToken
+  [TokenType.Array]: ArrayToken,
+  [TokenType.Object]: ObjectToken,
+  [TokenType.Property]: PropertyToken,
+  [TokenType.Annotation]: AnnotationToken,
+  [TokenType.Enum]: EnumToken,
+  [TokenType.EnumValue]: EnumValueToken,
+  [TokenType.EnumMemberValue]: EnumMemberValueToken,
+  [TokenType.Identifier]: IdentifierToken,
+  [TokenType.QualifiedEntityTypeName]: QualifiedEntityTypeNameToken,
+  [TokenType.QualifiedComplexTypeName]: QualifiedComplexTypeNameToken,
+  [TokenType.ODataIdentifier]: ODataIdentifierToken,
+  [TokenType.Collection]: CollectionToken,
+  [TokenType.NamespacePart]: NamespacePartToken,
+  [TokenType.EntitySetName]: EntitySetNameToken,
+  [TokenType.SingletonEntity]: SingletonEntityToken,
+  [TokenType.EntityTypeName]: EntityTypeNameToken,
+  [TokenType.ComplexTypeName]: ComplexTypeNameToken,
+  [TokenType.TypeDefinitionName]: TypeDefinitionNameToken,
+  [TokenType.EnumerationTypeName]: EnumerationTypeNameToken,
+  [TokenType.EnumerationMember]: EnumerationMemberToken,
+  [TokenType.TermName]: TermNameToken,
+  [TokenType.PrimitiveProperty]: PrimitivePropertyToken,
+  [TokenType.PrimitiveKeyProperty]: PrimitiveKeyPropertyToken,
+  [TokenType.PrimitiveNonKeyProperty]: PrimitiveNonKeyPropertyToken,
+  [TokenType.PrimitiveCollectionProperty]: PrimitiveCollectionPropertyToken,
+  [TokenType.ComplexProperty]: ComplexPropertyToken,
+  [TokenType.ComplexCollectionProperty]: ComplexCollectionPropertyToken,
+  [TokenType.StreamProperty]: StreamPropertyToken,
+  [TokenType.NavigationProperty]: NavigationPropertyToken,
+  [TokenType.EntityNavigationProperty]: EntityNavigationPropertyToken,
+  [TokenType.EntityCollectionNavigationProperty]: EntityCollectionNavigationPropertyToken,
+  [TokenType.Action]: ActionToken,
+  [TokenType.ActionImport]: ActionImportToken,
+  [TokenType.Function]: FunctionToken,
+  [TokenType.EntityFunction]: EntityFunctionToken,
+  [TokenType.EntityCollectionFunction]: EntityCollectionFunctionToken,
+  [TokenType.ComplexFunction]: ComplexFunctionToken,
+  [TokenType.ComplexCollectionFunction]: ComplexCollectionFunctionToken,
+  [TokenType.PrimitiveFunction]: PrimitiveFunctionToken,
+  [TokenType.PrimitiveCollectionFunction]: PrimitiveCollectionFunctionToken,
+  [TokenType.EntityFunctionImport]: EntityFunctionImportToken,
+  [TokenType.EntityCollectionFunctionImport]: EntityCollectionFunctionImportToken,
+  [TokenType.ComplexFunctionImport]: ComplexFunctionImportToken,
+  [TokenType.ComplexCollectionFunctionImport]: ComplexCollectionFunctionImportToken,
+  [TokenType.PrimitiveFunctionImport]: PrimitiveFunctionImportToken,
+  [TokenType.PrimitiveCollectionFunctionImport]: PrimitiveCollectionFunctionImportToken,
+  [TokenType.CommonExpression]: CommonExpressionToken,
+  [TokenType.AndExpression]: AndExpressionToken,
+  [TokenType.OrExpression]: OrExpressionToken,
+  [TokenType.EqualsExpression]: EqualsExpressionToken,
+  [TokenType.NotEqualsExpression]: NotEqualsExpressionToken,
+  [TokenType.LesserThanExpression]: LesserThanExpressionToken,
+  [TokenType.LesserOrEqualsExpression]: LesserOrEqualsExpressionToken,
+  [TokenType.GreaterThanExpression]: GreaterThanExpressionToken,
+  [TokenType.GreaterOrEqualsExpression]: GreaterOrEqualsExpressionToken,
+  [TokenType.HasExpression]: HasExpressionToken,
+  [TokenType.AddExpression]: AddExpressionToken,
+  [TokenType.SubExpression]: SubExpressionToken,
+  [TokenType.MulExpression]: MulExpressionToken,
+  [TokenType.DivExpression]: DivExpressionToken,
+  [TokenType.ModExpression]: ModExpressionToken,
+  [TokenType.NotExpression]: NotExpressionToken,
+  [TokenType.BoolParenExpression]: BoolParenExpressionToken,
+  [TokenType.ParenExpression]: ParenExpressionToken,
+  [TokenType.MethodCallExpression]: MethodCallExpressionToken,
+  [TokenType.IsOfExpression]: IsOfExpressionToken,
+  [TokenType.CastExpression]: CastExpressionToken,
+  [TokenType.NegateExpression]: NegateExpressionToken,
+  [TokenType.FirstMemberExpression]: FirstMemberExpressionToken,
+  [TokenType.MemberExpression]: MemberExpressionToken,
+  [TokenType.PropertyPathExpression]: PropertyPathExpressionToken,
+  [TokenType.ImplicitVariableExpression]: ImplicitVariableExpressionToken,
+  [TokenType.LambdaVariable]: LambdaVariableToken,
+  [TokenType.LambdaVariableExpression]: LambdaVariableExpressionToken,
+  [TokenType.LambdaPredicateExpression]: LambdaPredicateExpressionToken,
+  [TokenType.AnyExpression]: AnyExpressionToken,
+  [TokenType.AllExpression]: AllExpressionToken,
+  [TokenType.CollectionNavigationExpression]: CollectionNavigationExpressionToken,
+  [TokenType.SimpleKey]: SimpleKeyToken,
+  [TokenType.CompoundKey]: CompoundKeyToken,
+  [TokenType.KeyValuePair]: KeyValuePairToken,
+  [TokenType.KeyPropertyValue]: KeyPropertyValueToken,
+  [TokenType.KeyPropertyAlias]: KeyPropertyAliasToken,
+  [TokenType.SingleNavigationExpression]: SingleNavigationExpressionToken,
+  [TokenType.CollectionPathExpression]: CollectionPathExpressionToken,
+  [TokenType.ComplexPathExpression]: ComplexPathExpressionToken,
+  [TokenType.SinglePathExpression]: SinglePathExpressionToken,
+  [TokenType.FunctionExpression]: FunctionExpressionToken,
+  [TokenType.FunctionExpressionParameters]: FunctionExpressionParametersToken,
+  [TokenType.FunctionExpressionParameter]: FunctionExpressionParameterToken,
+  [TokenType.ParameterName]: ParameterNameToken,
+  [TokenType.ParameterAlias]: ParameterAliasToken,
+  [TokenType.ParameterValue]: ParameterValueToken,
+  [TokenType.CountExpression]: CountExpressionToken,
+  [TokenType.RefExpression]: RefExpressionToken,
+  [TokenType.ValueExpression]: ValueExpressionToken,
+  [TokenType.RootExpression]: RootExpressionToken,
+  [TokenType.QueryOptions]: QueryOptionsToken,
+  [TokenType.CustomQueryOption]: CustomQueryOptionToken,
+  [TokenType.Expand]: ExpandToken,
+  [TokenType.ExpandItem]: ExpandItemToken,
+  [TokenType.ExpandPath]: ExpandPathToken,
+  [TokenType.ExpandCountOption]: ExpandCountOptionToken,
+  [TokenType.ExpandRefOption]: ExpandRefOptionToken,
+  [TokenType.ExpandOption]: ExpandOptionToken,
+  [TokenType.Levels]: LevelsToken,
+  [TokenType.Search]: SearchToken,
+  [TokenType.SearchExpression]: SearchExpressionToken,
+  [TokenType.SearchParenExpression]: SearchParenExpressionToken,
+  [TokenType.SearchNotExpression]: SearchNotExpressionToken,
+  [TokenType.SearchOrExpression]: SearchOrExpressionToken,
+  [TokenType.SearchAndExpression]: SearchAndExpressionToken,
+  [TokenType.SearchTerm]: SearchTermToken,
+  [TokenType.SearchPhrase]: SearchPhraseToken,
+  [TokenType.SearchWord]: SearchWordToken,
+  [TokenType.Filter]: FilterToken,
+  [TokenType.OrderBy]: OrderByToken,
+  [TokenType.OrderByItem]: OrderByItemToken,
+  [TokenType.Skip]: SkipToken,
+  [TokenType.Top]: TopToken,
+  [TokenType.Format]: FormatToken,
+  [TokenType.InlineCount]: InlineCountToken,
+  [TokenType.Select]: SelectToken,
+  [TokenType.SelectItem]: SelectItemToken,
+  [TokenType.SelectPath]: SelectPathToken,
+  [TokenType.AliasAndValue]: AliasAndValueToken,
+  [TokenType.SkipToken]: SkipTokenToken,
+  [TokenType.Id]: IdToken,
+  [TokenType.Crossjoin]: CrossjoinToken,
+  [TokenType.AllResource]: AllResourceToken,
+  [TokenType.ActionImportCall]: ActionImportCallToken,
+  [TokenType.EntityCollectionFunctionImportCall]: EntityCollectionFunctionImportCallToken,
+  [TokenType.EntityFunctionImportCall]: EntityFunctionImportCallToken,
+  [TokenType.ComplexCollectionFunctionImportCall]: ComplexCollectionFunctionImportCallToken,
+  [TokenType.ComplexFunctionImportCall]: ComplexFunctionImportCallToken,
+  [TokenType.PrimitiveCollectionFunctionImportCall]: PrimitiveCollectionFunctionImportCallToken,
+  [TokenType.PrimitiveFunctionImportCall]: PrimitiveFunctionImportCallToken,
+  [TokenType.FunctionParameters]: FunctionParametersToken,
+  [TokenType.FunctionParameter]: FunctionParameterToken,
+  [TokenType.ResourcePath]: ResourcePathToken,
+  [TokenType.CollectionNavigation]: CollectionNavigationToken,
+  [TokenType.CollectionNavigationPath]: CollectionNavigationPathToken,
+  [TokenType.SingleNavigation]: SingleNavigationToken,
+  [TokenType.PropertyPath]: PropertyPathToken,
+  [TokenType.ComplexPath]: ComplexPathToken,
+  [TokenType.BoundOperation]: BoundOperationToken,
+  [TokenType.BoundActionCall]: BoundActionCallToken,
+  [TokenType.BoundEntityFunctionCall]: BoundEntityFunctionCallToken,
+  [TokenType.BoundEntityCollectionFunctionCall]: BoundEntityCollectionFunctionCallToken,
+  [TokenType.BoundComplexFunctionCall]: BoundComplexFunctionCallToken,
+  [TokenType.BoundComplexCollectionFunctionCall]: BoundComplexCollectionFunctionCallToken,
+  [TokenType.BoundPrimitiveFunctionCall]: BoundPrimitiveFunctionCallToken,
+  [TokenType.BoundPrimitiveCollectionFunctionCall]: BoundPrimitiveCollectionFunctionCallToken,
+  [TokenType.ODataUri]: ODataUriToken,
+  [TokenType.Batch]: BatchToken,
+  [TokenType.Entity]: EntityToken,
+  [TokenType.Metadata]: MetadataToken
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,0 @@
-import { Token } from './lexer';
-
-export interface QueryOptionsNode extends Token {
-  value: Array<Token>;
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,5 @@
 import { map } from '@newdash/newdash/map';
 import { Token, TokenType } from './lexer';
-import {
-  CustomQueryOptionToken,
-  ExpandToken,
-  FormatToken,
-  SearchToken,
-  SkipToken,
-  TopToken
-} from './token';
 import { createTraverser } from './visitor';
 
 export type SourceArray = number[] | Uint16Array;
@@ -57,15 +49,25 @@ export function required(
   return i >= (min || 0) && i <= max ? index + i : 0;
 }
 
-export function isType(
-  node: Token,
-  type: TokenType.CustomQueryOption
-): node is CustomQueryOptionToken;
-export function isType(node: Token, type: TokenType.Skip): node is SkipToken;
-export function isType(node: Token, type: TokenType.Top): node is TopToken;
-export function isType(node: Token, type: TokenType): boolean {
+export function isType<T extends TokenType>(
+  node: Token<any>,
+  type: T
+): node is Token<T> {
   return node?.type == type;
 }
+
+export function assertType<T extends TokenType>(
+  token: any,
+  tokenType: T
+): asserts token is Token<T> {
+  if (!(token instanceof Token) || !isType(token, tokenType)) {
+    const received = token instanceof Token
+      ? `token of type ${token.type}`
+      : `object: ${JSON.stringify(token)}`;
+    throw new Error(`Expected token of type ${tokenType}, received ${received}`);
+  }
+}
+
 
 /**
  * find one node in ast node by type
@@ -73,16 +75,10 @@ export function isType(node: Token, type: TokenType): boolean {
  * @param node
  * @param type
  */
-export function findOne(node: Token, type: TokenType.Top): TopToken;
-export function findOne(node: Token, type: TokenType.Skip): SkipToken;
-export function findOne(node: Token, type: TokenType.Expand): ExpandToken;
-export function findOne(node: Token, type: TokenType.Format): FormatToken;
-export function findOne(node: Token, type: TokenType.Search): SearchToken;
-export function findOne(node: Token, type: TokenType): Token;
-export function findOne(node: Token, type: any): Token {
-  let rt: Token;
+export function findOne<T extends TokenType>(node: Token<any>, type: T): Token<T> {
+  let rt: Token<T>;
   createTraverser({
-    [type]: (v: Token) => {
+    [type]: (v: Token<T>) => {
       rt = v;
     }
   })(node);
@@ -95,10 +91,10 @@ export function findOne(node: Token, type: any): Token {
  * @param node
  * @param type
  */
-export function findAll(node: Token, type: TokenType): Array<Token> {
-  const rt: Array<Token> = [];
+export function findAll<T extends TokenType>(node: Token<any>, type: T): Array<Token<T>> {
+  const rt: Array<Token<T>> = [];
   createTraverser({
-    [type]: (v: Token) => {
+    [type]: (v: Token<T>) => {
       rt.push(v);
     }
   })(node);

--- a/test/__snapshots__/filter.spec.ts.snap
+++ b/test/__snapshots__/filter.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Filter Test Suite shuold support filter with double quote 1`] = `"$filter=key eq 'val"'"`;
+exports[`Filter Test Suite should support filter with double quote 1`] = `"$filter=key eq 'val"'"`;
 
-exports[`Filter Test Suite shuold support filter with double quote 2`] = `
+exports[`Filter Test Suite should support filter with double quote 2`] = `
 Token {
   "next": 21,
   "position": 0,
@@ -63,9 +63,9 @@ Token {
 }
 `;
 
-exports[`Filter Test Suite shuold support filter with other chars 1`] = `"$filter=key eq 'val$%^&*()_'"`;
+exports[`Filter Test Suite should support filter with other chars 1`] = `"$filter=key eq 'val$%^&*()_'"`;
 
-exports[`Filter Test Suite shuold support filter with other chars 2`] = `
+exports[`Filter Test Suite should support filter with other chars 2`] = `
 Token {
   "next": 28,
   "position": 0,
@@ -126,9 +126,9 @@ Token {
 }
 `;
 
-exports[`Filter Test Suite shuold support filter with single quote 1`] = `"$filter=key eq 'T''A First'"`;
+exports[`Filter Test Suite should support filter with single quote 1`] = `"$filter=key eq 'T''A First'"`;
 
-exports[`Filter Test Suite shuold support filter with single quote 2`] = `
+exports[`Filter Test Suite should support filter with single quote 2`] = `
 Token {
   "next": 27,
   "position": 0,
@@ -189,9 +189,9 @@ Token {
 }
 `;
 
-exports[`Filter Test Suite shuold support filter without double quote 1`] = `"$filter=key eq 'val'"`;
+exports[`Filter Test Suite should support filter without double quote 1`] = `"$filter=key eq 'val'"`;
 
-exports[`Filter Test Suite shuold support filter without double quote 2`] = `
+exports[`Filter Test Suite should support filter without double quote 2`] = `
 Token {
   "next": 20,
   "position": 0,

--- a/test/__snapshots__/parser.spec.ts.snap
+++ b/test/__snapshots__/parser.spec.ts.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Parser should instantiate odata parser 1`] = `
+Token {
+  "next": 35,
+  "position": 0,
+  "raw": "Categories/all(d:d/Title eq 'alma')",
+  "type": "CommonExpression",
+  "value": Token {
+    "next": 35,
+    "position": 0,
+    "raw": "Categories/all(d:d/Title eq 'alma')",
+    "type": "FirstMemberExpression",
+    "value": Token {
+      "next": 35,
+      "position": 0,
+      "raw": "Categories/all(d:d/Title eq 'alma')",
+      "type": "MemberExpression",
+      "value": Token {
+        "next": 35,
+        "position": 0,
+        "raw": "Categories/all(d:d/Title eq 'alma')",
+        "type": "PropertyPathExpression",
+        "value": {
+          "current": Token {
+            "next": 10,
+            "position": 0,
+            "raw": "Categories",
+            "type": "ODataIdentifier",
+            "value": {
+              "name": "Categories",
+            },
+          },
+          "next": Token {
+            "next": 35,
+            "position": 10,
+            "raw": "/all(d:d/Title eq 'alma')",
+            "type": "CollectionPathExpression",
+            "value": Token {
+              "next": 35,
+              "position": 11,
+              "raw": "all(d:d/Title eq 'alma')",
+              "type": "AllExpression",
+              "value": {
+                "predicate": Token {
+                  "next": 34,
+                  "position": 17,
+                  "raw": "d/Title eq 'alma'",
+                  "type": "LambdaPredicateExpression",
+                  "value": Token {
+                    "next": 34,
+                    "position": 17,
+                    "raw": "d/Title eq 'alma'",
+                    "type": "EqualsExpression",
+                    "value": {
+                      "left": Token {
+                        "next": 24,
+                        "position": 17,
+                        "raw": "d/Title",
+                        "type": "FirstMemberExpression",
+                        "value": [
+                          Token {
+                            "next": 18,
+                            "position": 17,
+                            "raw": "d",
+                            "type": "LambdaVariableExpression",
+                            "value": {
+                              "name": "d",
+                            },
+                          },
+                          Token {
+                            "next": 24,
+                            "position": 19,
+                            "raw": "Title",
+                            "type": "MemberExpression",
+                            "value": Token {
+                              "next": 24,
+                              "position": 19,
+                              "raw": "Title",
+                              "type": "PropertyPathExpression",
+                              "value": Token {
+                                "next": 24,
+                                "position": 19,
+                                "raw": "Title",
+                                "type": "ODataIdentifier",
+                                "value": {
+                                  "name": "Title",
+                                },
+                              },
+                            },
+                          },
+                        ],
+                      },
+                      "right": Token {
+                        "next": 34,
+                        "position": 28,
+                        "raw": "'alma'",
+                        "type": "Literal",
+                        "value": "Edm.String",
+                      },
+                    },
+                  },
+                },
+                "variable": Token {
+                  "next": 16,
+                  "position": 15,
+                  "raw": "d",
+                  "type": "LambdaVariableExpression",
+                  "value": {
+                    "name": "d",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/test/builder/filter.test.ts
+++ b/test/builder/filter.test.ts
@@ -1,13 +1,10 @@
 import { filter, literalValues, ODataFilter } from '../../src';
 
 describe('OData Query Builder - Filter Test Suite', () => {
-
   it('should support filter by value/name', () => {
-
     expect(ODataFilter.New().field('A').eq('a').toString()).toBe("A eq 'a'");
     expect(ODataFilter.New().field('A').eq(literalValues.String('a')).toString()).toBe("A eq 'a'");
     expect(ODataFilter.New().field('A').eq(1).toString()).toBe('A eq 1');
-
   });
 
   it('should support filter by object', () => {
@@ -46,5 +43,4 @@ describe('OData Query Builder - Filter Test Suite', () => {
     expect(filter({ A: literalValues.String('1') }).build()).toBe("A eq '1'");
     expect(filter({ A: literalValues.Guid('253f842d-d739-41b8-ac8c-139ac7a9dd14') }).build()).toBe('A eq 253f842d-d739-41b8-ac8c-139ac7a9dd14');
   });
-
 });

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -2,9 +2,7 @@ import { get } from '@newdash/newdash';
 import { Edm } from '@odata/metadata';
 import { defaultParser, ODataFilter, ODataParam } from '../src';
 
-
 describe('Filter Test Suite', () => {
-
   it('should support simple eq', () => {
     defaultParser.query('$format=json&$filter=A eq 2');
   });
@@ -20,40 +18,39 @@ describe('Filter Test Suite', () => {
     expect(get(ast, 'value.options[0].value.value.right.value.right.value')).toBe(Edm.String.className);
   });
 
-  it('shuold support filter without double quote', () => {
-    const filter = ODataFilter.New().field("key").eq('val')
-    const filterStr = ODataParam.New().filter(filter).toString()
-    expect(filterStr).toMatchSnapshot()
-    const ast = defaultParser.query(filterStr)
-    expect(ast).toMatchSnapshot()
-  })
+  it('should support filter without double quote', () => {
+    const filter = ODataFilter.New().field('key').eq('val');
+    const filterStr = ODataParam.New().filter(filter).toString();
+    expect(filterStr).toMatchSnapshot();
+    const ast = defaultParser.query(filterStr);
+    expect(ast).toMatchSnapshot();
+  });
 
-  it('shuold support filter with other chars', () => {
-    const filter = ODataFilter.New().field("key").eq('val$%^&*()_')
-    const filterStr = ODataParam.New().filter(filter).toString()
-    expect(filterStr).toMatchSnapshot()
-    const ast = defaultParser.query(filterStr)
-    expect(ast).toMatchSnapshot()
-  })
+  it('should support filter with other chars', () => {
+    const filter = ODataFilter.New().field('key').eq('val$%^&*()_');
+    const filterStr = ODataParam.New().filter(filter).toString();
+    expect(filterStr).toMatchSnapshot();
+    const ast = defaultParser.query(filterStr);
+    expect(ast).toMatchSnapshot();
+  });
 
-  it('shuold support filter with double quote', () => {
-    const filter = ODataFilter.New().field("key").eq('val"')
-    const filterStr = ODataParam.New().filter(filter).toString()
-    expect(filterStr).toMatchSnapshot()
-    const ast = defaultParser.query(filterStr)
-    expect(ast).toMatchSnapshot()
-  })
+  it('should support filter with double quote', () => {
+    const filter = ODataFilter.New().field('key').eq('val"');
+    const filterStr = ODataParam.New().filter(filter).toString();
+    expect(filterStr).toMatchSnapshot();
+    const ast = defaultParser.query(filterStr);
+    expect(ast).toMatchSnapshot();
+  });
 
-  it('shuold support filter with single quote', () => {
-    const filter = ODataFilter.New().field("key").eq("T''A First")
-    const filterStr = ODataParam.New().filter(filter).toString()
-    expect(filterStr).toMatchSnapshot()
-    const ast = defaultParser.query(filterStr)
-    expect(ast).toMatchSnapshot()
-  })
+  it('should support filter with single quote', () => {
+    const filter = ODataFilter.New().field('key').eq("T''A First");
+    const filterStr = ODataParam.New().filter(filter).toString();
+    expect(filterStr).toMatchSnapshot();
+    const ast = defaultParser.query(filterStr);
+    expect(ast).toMatchSnapshot();
+  });
 
   it('should support complex filter', () => {
-
     const sFilter = ODataFilter.New()
       .field('A').eq(1).field('A').eq(2)
       .field('B').gt(3)
@@ -66,7 +63,5 @@ describe('Filter Test Suite', () => {
       .toString();
 
     defaultParser.filter(sFilter);
-
   });
-
 });

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -1,16 +1,12 @@
-import { defaultParser, TokenType } from '../src';
+import { defaultParser, Token, TokenType } from '../src';
 import { Parser } from '../src/parser';
-import { isType } from '../src/utils';
+import { assertType, isType } from '../src/utils';
 
 describe('Parser', () => {
-
   it('should instantiate odata parser', () => {
     const parser = new Parser();
     const ast = parser.filter("Categories/all(d:d/Title eq 'alma')");
-    expect(
-      ast.value.value.value.value.next.value.value.predicate.value.value.right
-        .value
-    ).toEqual('Edm.String');
+    expect(ast).toMatchSnapshot();
   });
 
   it('should parse query string', () => {
@@ -22,6 +18,7 @@ describe('Parser', () => {
   it('should parse functions with parameters', () => {
     const parser = new Parser();
     const ast = parser.filter("matchespattern(Title, '^foo.+')");
+    assertType(ast, TokenType.MethodCallExpression);
     expect(ast.type).toEqual('MethodCallExpression');
     expect(ast.value.method).toEqual('matchespattern');
     expect(ast.value.parameters[0].raw).toEqual('Title');
@@ -32,6 +29,7 @@ describe('Parser', () => {
   it('should parse multiple orderby params', () => {
     const parser = new Parser();
     const ast = parser.query('$orderby=foo,bar');
+    assertItems(ast.value.options[0]);
     expect(ast.value.options[0].value.items[0].raw).toEqual('foo');
     expect(ast.value.options[0].value.items[1].raw).toEqual('bar');
   });
@@ -39,6 +37,7 @@ describe('Parser', () => {
   it('should parse multiple orderby params with optional space', () => {
     const parser = new Parser();
     const ast = parser.query('$orderby=foo, bar');
+    assertItems(ast.value.options[0]);
     expect(ast.value.options[0].value.items[0].raw).toEqual('foo');
     expect(ast.value.options[0].value.items[1].raw).toEqual('bar');
   });
@@ -65,3 +64,11 @@ describe('Parser', () => {
     expect(() => {defaultParser.query('$foo=123');}).toThrow();
   });
 });
+
+function assertItems<T extends TokenType>(
+  token: Token<T>
+): asserts token is Token<T> & { value: { items: Token[] } } {
+  if (typeof token.value !== 'object' || !('items' in token.value)) {
+    throw new Error();
+  }
+}

--- a/test/primitiveLiteral.spec.ts
+++ b/test/primitiveLiteral.spec.ts
@@ -4,7 +4,7 @@ import * as PrimitiveLiteral from '../src/primitiveLiteral';
 import cases from './primitive-cases';
 
 describe('Primitive literals from json', () => {
-  cases.forEach((item, index, array) => {
+  cases.forEach((item, index) => {
     const title = `#${index} should parse ${item['-Name']}: ${item.Input}`;
     let resultName = 'result';
     if (item.result === undefined) {

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -1,46 +1,38 @@
 import { get } from '@newdash/newdash';
 import { PrimitiveTypeEnum } from '@odata/metadata';
-import { defaultParser, ODataFilter, ODataParam } from '../src';
+import { ODataFilter, ODataParam } from '../src';
 import { TokenType } from '../src/lexer';
 import { Parser } from '../src/parser';
-import { findAll, findOne, isType } from '../src/utils';
+import { assertType, findAll, findOne, isType } from '../src/utils';
 
 describe('Query Test Suite', () => {
-
   const parser = new Parser();
 
   const expands = [
-    [ODataParam.New().expand('A').toString(), 'A'],
-    [ODataParam.New().expand('A/V').toString(), 'A/V'],
-    [ODataParam.New().expand('A/B/C').toString(), 'A/B/C'],
-    [ODataParam.New().expand(['A', 'B/C']).toString(), 'A'],
-    [ODataParam.New().expand('*').toString(), '*']
+    { original: ODataParam.New().expand('A').toString(), parsed: 'A' },
+    { original: ODataParam.New().expand('A/V').toString(), parsed: 'A/V' },
+    { original: ODataParam.New().expand('A/B/C').toString(), parsed: 'A/B/C' },
+    { original: ODataParam.New().expand(['A', 'B/C']).toString(), parsed: 'A' },
+    { original: ODataParam.New().expand('*').toString(), parsed: '*' }
   ];
 
-  expands.forEach(([original, parsed]) => {
-
-    it(`should parse ${original}`, () => {
-
-      expect(parser.query(original).value.options[0].value.items[0].raw).toEqual(parsed);
-
-    });
-
+  it.each(expands)(`should parse $original`, ({ original, parsed }) => {
+    const ast = parser.query(original);
+    assertType(ast.value.options[0], TokenType.Expand);
+    expect(ast.value.options[0].value.items[0].raw).toEqual(parsed);
   });
 
   it('should parse $top', () => {
-
     const ast = parser.query('$top=1');
 
     expect(ast.value.options[0].type).toBe(TokenType.Top);
 
-    if (isType(ast.value.options[0], TokenType.Top)) {
-      expect(ast.value.options[0].value.raw).toEqual('1');
-    }
-
+    assertType(ast.value.options[0], TokenType.Top);
+    expect(ast.value.options[0].value.raw).toEqual('1');
   });
 
   it('should parse $top and $skip', () => {
-    const ast = defaultParser.query('$top=1&$skip=120');
+    const ast = parser.query('$top=1&$skip=120');
     expect(ast.value.options[0].type).toBe(TokenType.Top);
     expect(ast.value.options[1].type).toBe(TokenType.Skip);
 
@@ -53,37 +45,50 @@ describe('Query Test Suite', () => {
   });
 
   it('should parse $select', () => {
-    expect(parser.query('$select=A').value.options[0].value.items[0].value.raw).toEqual('A');
-    expect(parser.query('$select=*').value.options[0].value.items[0].value.value).toEqual('*');
-    let ast = defaultParser.query('$select=A,B,C');
-    expect(findAll(ast, TokenType.SelectPath).map((node) => get(node, 'value.value.name'))
+    let ast = parser.query('$select=A');
+    assertType(ast.value.options[0], TokenType.Select);
+    assertType(ast.value.options[0].value.items[0].value, TokenType.SelectPath);
+    expect(ast.value.options[0].value.items[0].value.raw).toEqual('A');
+
+    ast = parser.query('$select=*');
+    assertType(ast.value.options[0], TokenType.Select);
+    expect(ast.value.options[0].value.items[0].value.value).toEqual('*');
+
+    ast = parser.query('$select=A,B,C');
+    expect(
+      findAll(ast, TokenType.SelectPath).map((node) => get(node, 'value.value.name'))
     ).toStrictEqual(['A', 'B', 'C']);
-    ast = defaultParser.query('$select=A, B,C');
-    expect(findAll(ast, TokenType.SelectPath).map((node) => get(node, 'value.value.name'))
+
+    ast = parser.query('$select=A, B,C');
+    expect(
+      findAll(ast, TokenType.SelectPath).map((node) => get(node, 'value.value.name'))
     ).toStrictEqual(['A', 'B', 'C']);
 
     parser.query('$select=A/B');
   });
 
   it('should parse $search', () => {
-
-    parser.query('$search=theo');
-    parser.query('$search="theo%20sun"');
-
+    expect(() => {
+      parser.query('$search=theo');
+      parser.query('$search="theo%20sun"');
+    }).not.toThrow();
   });
 
   it('should parse $orderby', () => {
-    parser.query('$orderby=A desc');
-    parser.query('$orderby=A desc,B asc');
-    parser.query('$orderby=A desc, B asc');
-
+    expect(() => {
+      parser.query('$orderby=A desc');
+      parser.query('$orderby=A desc,B asc');
+      parser.query('$orderby=A desc, B asc');
+    }).not.toThrow();
   });
 
   it('should parse $format', () => {
-    parser.query('$format=xml');
-    parser.query('$format=json');
-    parser.query('$format=JSON');
-    parser.query('$format=atom');
+    expect(() => {
+      parser.query('$format=xml');
+      parser.query('$format=json');
+      parser.query('$format=JSON');
+      parser.query('$format=atom');
+    }).not.toThrow();
   });
 
   it('should parse $count', () => {
@@ -93,15 +98,13 @@ describe('Query Test Suite', () => {
   });
 
   it('should parse $filter only', () => {
-    const ast = defaultParser.query('$filter=id eq 1');
+    const ast = parser.query('$filter=id eq 1');
     expect(ast).not.toBeUndefined();
     expect(ast.value.options).not.toBeUndefined();
     expect(ast.value.options).toHaveLength(1);
-
   });
 
   it('should parse complex uri', () => {
-
     const u1 = ODataParam.New()
       .top(1)
       .skip(10)
@@ -112,7 +115,8 @@ describe('Query Test Suite', () => {
       .expand('F1,F2')
       .filter(ODataFilter.New().field('A').eq(1).toString())
       .toString();
-    const ast = defaultParser.query(u1);
+
+    const ast = parser.query(u1);
 
     expect(findOne(ast, TokenType.Filter).value).not.toBeNull();
 
@@ -124,7 +128,6 @@ describe('Query Test Suite', () => {
       }
     });
     expect(findOne(ast, TokenType.Skip).value.raw).toBe('10');
-
     expect(findOne(ast, TokenType.Format).value.format).toBe('json');
     expect(findOne(ast, TokenType.Search).value.value).toBe('A');
 
@@ -134,7 +137,5 @@ describe('Query Test Suite', () => {
         .items
         .map((item) => item.raw)
     ).toStrictEqual(['F1', 'F2']);
-
   });
-
 });

--- a/test/visitor.spec.ts
+++ b/test/visitor.spec.ts
@@ -1,11 +1,10 @@
 import { createTraverser, defaultParser } from '../src';
 
 describe('Visitor Parse Suite', () => {
-
-  const createSeqTokenProcessor = (key: string, arr: Array<any>) => () => arr.push(key);
+  const createSeqTokenProcessor = (key: string, arr: string[]) => () => arr.push(key);
 
   const createSeqTraverser = (deepFirst = false) => {
-    const visitSequence = [];
+    const visitSequence: string[] = [];
 
     const visit = createTraverser({
       Top: createSeqTokenProcessor('param:top', visitSequence),
@@ -26,38 +25,31 @@ describe('Visitor Parse Suite', () => {
     return { visit, visitSequence };
   };
 
-
   it('should visit filter', () => {
-
     const expectedSeq = ['and', 'paren', 'eq', 'lit', 'paren', 'eq', 'lit'];
-
     const { visit, visitSequence } = createSeqTraverser();
-
     const node = defaultParser.filter('(A eq 2) and (V eq 3)');
 
     visit(node);
 
     expect(visitSequence).toEqual(expectedSeq);
-
   });
 
   it('should visit filter deep first', () => {
-
     const expectedSeq = ['lit', 'eq', 'lit', 'eq', 'or', 'paren', 'lit', 'eq', 'paren', 'and'];
-
     const { visit, visitSequence } = createSeqTraverser(true);
-
     const node = defaultParser.filter('(A eq 2 or A eq 3) and (V eq 3)');
 
     visit(node);
 
     expect(visitSequence).toEqual(expectedSeq);
-
   });
 
   it('should support visit undefined', () => {
-    const { visit, visitSequence } = createSeqTraverser(true);
-    visit(undefined as any);
-  });
+    const { visit } = createSeqTraverser(true);
 
+    expect(() => {
+      visit(undefined as any);
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Describe your changes

Prior to this change, all tokens had their values typed as `any`.  This makes working with a parsed query incredibly difficult, as it requires inspecting the token at every depth to determine not just the type, but also the structure of its value.

This change introduces a strict type/value combination for each token, allowing only the structures required for that that specific definition.

## Issue ticket number and link (if applicable)

N/A

## Checklist before requesting a review

- [x] Project license confirmed
- [x] Unit-test added & passed at local development environment
- [x] All CI check passed
- [x] Design Document (if applicable)
